### PR TITLE
Fix stepAtt issue and HiPriority packet test

### DIFF
--- a/Project Files/Source/Console/PSForm.cs
+++ b/Project Files/Source/Console/PSForm.cs
@@ -157,11 +157,13 @@ namespace Thetis
             set
             {
                 _psenabled = value;
+
                 if (_psenabled)
                 {
                     // Set the system to supply feedback.
                     console.UpdateDDCs(console.RX2Enabled);
                     NetworkIO.SetPureSignal(1);
+                    NetworkIO.SendHighPriority(1); // send the HP packet
                     //console.UpdateRXADCCtrl();
                     console.UpdateAAudioMixerStates();
                     unsafe { cmaster.LoadRouterControlBit((void*)0, 0, 0, 1); }
@@ -172,14 +174,16 @@ namespace Thetis
                     // Set the system to turn-off feedback.
                     console.UpdateDDCs(console.RX2Enabled);
                     NetworkIO.SetPureSignal(0);
+                    NetworkIO.SendHighPriority(1); // send the HP packet
                     //console.UpdateRXADCCtrl();
                     console.UpdateAAudioMixerStates();
                     unsafe { cmaster.LoadRouterControlBit((void*)0, 0, 0, 0); }
                     console.radio.GetDSPTX(0).PSRunCal = false;
                 }
-               // console.EnableDup();
+                                               
+                // console.EnableDup();
                 if (console.path_Illustrator != null)
-                    console.path_Illustrator.pi_Changed();
+                    console.path_Illustrator.pi_Changed();                
             }
         }
 

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -33270,8 +33270,18 @@ namespace Thetis
             //consider psstate ??
             if (!RX2Enabled || !tx)
             {
+                if (tx)
+                {
+                    if (!VFOATX && VFOBTX)
+                        txtVFOBFreq_LostFocus(this, EventArgs.Empty);
+                    else if (VFOATX && !VFOBTX)
+                        txtVFOAFreq_LostFocus(this, EventArgs.Empty);
+                }
+                else
+                { 
                 txtVFOAFreq_LostFocus(this, EventArgs.Empty);
                 txtVFOBFreq_LostFocus(this, EventArgs.Empty);
+                    }
             }
             else
             {


### PR DESCRIPTION
Fixes : #48 

Also, I noticed that PS-A was not locking/calibrating under the following conditions :

1) PS-A off
2) Step att set to change to 31dB on tx
3) Mox pressed
4) Then PS-A on
5) Wouldnt lock unless I moved step atten

Discovered that hiprio call has been removed from NetworkIO.SetPureSignal so a call to SendHighPriority(1) just after SetPureSignal call inside PSEnable (psform) and it seems to have fixed the issue.