### PR TITLE
Changes to ZZRV

### DIFF
--- a/Project Files/Source/Console/CAT/CATCommands.cs
+++ b/Project Files/Source/Console/CAT/CATCommands.cs
@@ -5524,19 +5524,25 @@ namespace Thetis
         //Reads the primary input voltage
         public string ZZRV()
         {
-            if (console.CurrentHPSDRModel != HPSDRModel.HPSDR)
+            //MW0LGE [2.10.1.0]
+            if (console.CurrentHPSDRModel == HPSDRModel.ANAN7000D || console.CurrentHPSDRModel == HPSDRModel.ANAN8000D ||
+                    console.CurrentHPSDRModel == HPSDRModel.ANAN_G2 || console.CurrentHPSDRModel == HPSDRModel.ANAN_G2_1K)
             {
-                int val = 0;
-                decimal volts = 0.0m;
-                volts = (decimal)val / 4096m * 2.5m * 11m;
-                return Decimal.Round(volts, 1).ToString();
+				return String.Format("{0:00.0}", console.MKIIPAVolts);
+            }
+            else if (console.CurrentHPSDRModel != HPSDRModel.HPSDR)
+            {
+				//int val = 0;
+				//decimal volts = 0.0m;
+				//volts = (decimal)val / 4096m * 2.5m * 11m;
+				//return Decimal.Round(volts, 1).ToString();
+				return "00.0";
             }
             else
             {
                 parser.Verbose_Error_Code = 7;
                 return parser.Error1;
             }
-
         }
 
         // Sets or reads the RX1 step attenuation control, 0 to 31dB

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -27481,6 +27481,10 @@ namespace Thetis
         private float _MKIIPAAmps = 0f;
         private ConcurrentQueue<int> _voltsQueue = new ConcurrentQueue<int>();
         private ConcurrentQueue<int> _ampsQueue = new ConcurrentQueue<int>();
+        public float MKIIPAVolts
+        {
+            get { return _MKIIPAVolts; }
+        }
         private async void readMKIIPAVoltsAmps()
         {
             // MW0LGE_21k9c


### PR DESCRIPTION
Now returns MKII volts., otherwise will always be 00.0 unless radio is HPSDR where it return a parse error (maintain previous behaviour).

Format returned

ZZRV00.0;

https://github.com/ramdor/Thetis/issues/143