### PR TITLE
Incorrect display buffers used when RX2 enabled

### DIFF
--- a/Project Files/Source/Console/titlebar.cs
+++ b/Project Files/Source/Console/titlebar.cs
@@ -34,8 +34,8 @@ namespace Thetis
 {
     class TitleBar
     {
-        public const string BUILD_NAME = "";
-        public const string BUILD_DATE = "(8/23/23)<FW>"; //MW0LGE_21g <FW> gets replaced in BasicTitle (console.cs) with firmware version
+        public const string BUILD_NAME = "wip_lge_8";
+        public const string BUILD_DATE = "(10/02/23)<FW>"; //MW0LGE_21g <FW> gets replaced in BasicTitle (console.cs) with firmware version
 
         public static string GetString()
         {


### PR DESCRIPTION

Fixes issue if RX2 is shown then RX1 tracks the noise floor incorrectly from time to time. RX1 and RX2 were sharing same data copy incorrectly.