### PR TITLE
Quick Split Added

### DIFF
--- a/Project Files/Source/Console/CAT/CATCommands.cs
+++ b/Project Files/Source/Console/CAT/CATCommands.cs
@@ -8020,6 +8020,53 @@ namespace Thetis
                 return parser.Error1;
             }
         }
+		//[2.10.1.0]MW0LGE enable/disable quick split mode
+		public string ZZZN(string s)
+		{
+            if (console is null || console.Midi2Cat is null) return parser.Error1;
+
+            if (s.Length == parser.nSet && (s == "0" || s == "1"))
+            {
+				if(!console.IsSetupFormNull)
+					console.SetupForm.QuickSplitEnabled = (s == "1");
+                return "";
+            }
+            else if (s.Length == parser.nGet)
+            {
+				bool bRet = false;
+				if (!console.IsSetupFormNull) bRet = console.SetupForm.QuickSplitEnabled;
+                return bRet ? "1" : "0";
+            }
+            else
+            {
+                return parser.Error1;
+            }
+        }
+        //[2.10.1.0]MW0LGE enable/disable quick split and turn split on/off at same time
+        public string ZZZO(string s)
+        {
+            if (console is null || console.Midi2Cat is null) return parser.Error1;
+
+            if (s.Length == parser.nSet && (s == "0" || s == "1"))
+            {
+                if (!console.IsSetupFormNull)
+                    console.SetupForm.QuickSplitEnabled = (s == "1");
+
+				console.VFOSplit = (s == "1");
+
+                return "";
+            }
+            else if (s.Length == parser.nGet)
+            {
+				bool bRet = console.VFOSplit;
+				if (!console.IsSetupFormNull) bRet &= console.SetupForm.QuickSplitEnabled;				
+                return bRet ? "1" : "0";
+            }
+            else
+            {
+                return parser.Error1;
+            }
+        }
         #endregion Extended CAT Methods ZZR-ZZZ
 
 

--- a/Project Files/Source/Console/CAT/CATParser.cs
+++ b/Project Files/Source/Console/CAT/CATParser.cs
@@ -1485,7 +1485,13 @@ namespace Thetis
 				case "ZZZZ":
 					rtncmd = cmdlist.ZZZZ();
 					break;
-			}
+				case "ZZZN":
+					rtncmd = cmdlist.ZZZN(suffix);
+					break;
+                case "ZZZO":
+                    rtncmd = cmdlist.ZZZO(suffix);
+                    break;
+            }
             if (!rtncmd.Contains(Error1))
             //rtncmd != Error1 && rtncmd != Error2 && rtncmd != Error3)
             {

--- a/Project Files/Source/Console/CAT/CATStructs.xml
+++ b/Project Files/Source/Console/CAT/CATStructs.xml
@@ -2830,6 +2830,20 @@
 		<ngetparms>0</ngetparms>
 		<nansparms>1</nansparms>
 	</catstruct>
+	<catstruct code="ZZZN">
+		<desc>Enable Quick Split</desc>
+		<active>true</active>
+		<nsetparms>1</nsetparms>
+		<ngetparms>0</ngetparms>
+		<nansparms>1</nansparms>
+	</catstruct>
+	<catstruct code="ZZZO">
+		<desc>Enable Quick Split and VFO Split</desc>
+		<active>true</active>
+		<nsetparms>1</nsetparms>
+		<ngetparms>0</ngetparms>
+		<nansparms>1</nansparms>
+	</catstruct>	
 	<catstruct code="ZZZM">
 		<desc>Get Hardware Model</desc>
 		<active>true</active>

--- a/Project Files/Source/Console/Midi2CatCommands.cs
+++ b/Project Files/Source/Console/Midi2CatCommands.cs
@@ -6201,7 +6201,62 @@ namespace Thetis
             }
             return CmdState.NoChange;
         }
-        #endregion
+        public CmdState QuickSplitOnOff(int msg, MidiDevice device)
+        {
+            if (msg == 127)
+            {
+                parser.nGet = 0;
+                parser.nSet = 1;
 
+                int quickSplitEnabled = Convert.ToInt16(commands.ZZZN(""));
+
+                if (quickSplitEnabled == 0)
+                {
+                    commands.ZZZN("1");
+                    return CmdState.On;
+                }
+                if (quickSplitEnabled == 1)
+                {
+                    commands.ZZZN("0");
+                    return CmdState.Off;
+                }
+            }
+            return CmdState.NoChange;
+        }
+        public CmdState QuickSplitOnOffandSplitOnOff(int msg, MidiDevice device)
+        {
+            if (msg == 127)
+            {
+                parser.nGet = 0;
+                parser.nSet = 1;
+                
+                int quickSplitEnabled = Convert.ToInt16(commands.ZZZN(""));
+                int splitEnabled = Convert.ToInt16(commands.ZZSP(""));
+                bool oldState = quickSplitEnabled == 1 && splitEnabled == 1;
+
+                if (quickSplitEnabled == 0 || splitEnabled == 0)
+                {
+                    commands.ZZZN("1");
+                    commands.ZZSP("1");
+                }
+                else if (quickSplitEnabled == 1 || splitEnabled == 1)
+                {
+                    commands.ZZZN("0");
+                    commands.ZZSP("0");
+                }
+
+                quickSplitEnabled = Convert.ToInt16(commands.ZZZN(""));
+                splitEnabled = Convert.ToInt16(commands.ZZSP(""));
+                bool newState = quickSplitEnabled == 1 && splitEnabled == 1;
+                if (newState != oldState)
+                {
+                    return newState ? CmdState.On : CmdState.Off;
+                }
+                else
+                    return CmdState.NoChange;
+            }
+            return CmdState.NoChange;
+        }
+        #endregion
     }
 }

--- a/Project Files/Source/Console/console.Designer.cs
+++ b/Project Files/Source/Console/console.Designer.cs
@@ -2049,11 +2049,14 @@
             // chkVFOSplit
             // 
             resources.ApplyResources(this.chkVFOSplit, "chkVFOSplit");
+            this.chkVFOSplit.AutoCheck = false;
             this.chkVFOSplit.FlatAppearance.BorderSize = 0;
             this.chkVFOSplit.ForeColor = System.Drawing.SystemColors.ControlLightLight;
             this.chkVFOSplit.Name = "chkVFOSplit";
             this.toolTip1.SetToolTip(this.chkVFOSplit, resources.GetString("chkVFOSplit.ToolTip"));
             this.chkVFOSplit.CheckedChanged += new System.EventHandler(this.chkVFOSplit_CheckedChanged);
+            this.chkVFOSplit.MouseClick += new System.Windows.Forms.MouseEventHandler(this.chkVFOSplit_MouseClick);
+            this.chkVFOSplit.MouseDown += new System.Windows.Forms.MouseEventHandler(this.chkVFOSplit_MouseDown);
             // 
             // btnRITReset
             // 

--- a/Project Files/Source/Console/console.resx
+++ b/Project Files/Source/Console/console.resx
@@ -157,7 +157,7 @@
     <value>ptbFilterShift</value>
   </data>
   <data name="&gt;&gt;ptbFilterShift.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbFilterShift.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -193,7 +193,7 @@
     <value>ptbFilterWidth</value>
   </data>
   <data name="&gt;&gt;ptbFilterWidth.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbFilterWidth.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -232,7 +232,7 @@
     <value>btnFilterShiftReset</value>
   </data>
   <data name="&gt;&gt;btnFilterShiftReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnFilterShiftReset.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -265,7 +265,7 @@
     <value>udFilterHigh</value>
   </data>
   <data name="&gt;&gt;udFilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udFilterHigh.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -298,7 +298,7 @@
     <value>udFilterLow</value>
   </data>
   <data name="&gt;&gt;udFilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udFilterLow.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -334,7 +334,7 @@
     <value>ptbRX2RF</value>
   </data>
   <data name="&gt;&gt;ptbRX2RF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2RF.Parent" xml:space="preserve">
     <value>panelRX2RF</value>
@@ -370,7 +370,7 @@
     <value>lblRX2RF</value>
   </data>
   <data name="&gt;&gt;lblRX2RF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2RF.Parent" xml:space="preserve">
     <value>panelRX2RF</value>
@@ -418,7 +418,7 @@
     <value>chkFullDuplex</value>
   </data>
   <data name="&gt;&gt;chkFullDuplex.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFullDuplex.Parent" xml:space="preserve">
     <value>$this</value>
@@ -457,7 +457,7 @@
     <value>chkRX2Squelch</value>
   </data>
   <data name="&gt;&gt;chkRX2Squelch.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2Squelch.Parent" xml:space="preserve">
     <value>$this</value>
@@ -502,7 +502,7 @@
     <value>chkRX2Mute</value>
   </data>
   <data name="&gt;&gt;chkRX2Mute.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2Mute.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -547,7 +547,7 @@
     <value>chkRX2NB2</value>
   </data>
   <data name="&gt;&gt;chkRX2NB2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2NB2.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -592,7 +592,7 @@
     <value>chkRX2NR</value>
   </data>
   <data name="&gt;&gt;chkRX2NR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2NR.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -637,7 +637,7 @@
     <value>chkRX2NB</value>
   </data>
   <data name="&gt;&gt;chkRX2NB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2NB.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -673,7 +673,7 @@
     <value>lblRX2AGC</value>
   </data>
   <data name="&gt;&gt;lblRX2AGC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2AGC.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -718,7 +718,7 @@
     <value>chkRX2ANF</value>
   </data>
   <data name="&gt;&gt;chkRX2ANF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2ANF.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -745,7 +745,7 @@
     <value>comboRX2AGC</value>
   </data>
   <data name="&gt;&gt;comboRX2AGC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2AGC.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -790,7 +790,7 @@
     <value>chkRX2BIN</value>
   </data>
   <data name="&gt;&gt;chkRX2BIN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2BIN.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -835,7 +835,7 @@
     <value>chkExternalPA</value>
   </data>
   <data name="&gt;&gt;chkExternalPA.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkExternalPA.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -880,7 +880,7 @@
     <value>ckQuickPlay</value>
   </data>
   <data name="&gt;&gt;ckQuickPlay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ckQuickPlay.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -925,7 +925,7 @@
     <value>chkMON</value>
   </data>
   <data name="&gt;&gt;chkMON.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkMON.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -967,7 +967,7 @@
     <value>ckQuickRec</value>
   </data>
   <data name="&gt;&gt;ckQuickRec.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ckQuickRec.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1012,7 +1012,7 @@
     <value>chkRX2SR</value>
   </data>
   <data name="&gt;&gt;chkRX2SR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2SR.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1060,7 +1060,7 @@
     <value>chkMOX</value>
   </data>
   <data name="&gt;&gt;chkMOX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkMOX.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1108,7 +1108,7 @@
     <value>chkTUN</value>
   </data>
   <data name="&gt;&gt;chkTUN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkTUN.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1153,7 +1153,7 @@
     <value>chk2TONE</value>
   </data>
   <data name="&gt;&gt;chk2TONE.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chk2TONE.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1198,7 +1198,7 @@
     <value>chkFWCATUBypass</value>
   </data>
   <data name="&gt;&gt;chkFWCATUBypass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFWCATUBypass.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1240,7 +1240,7 @@
     <value>comboTuneMode</value>
   </data>
   <data name="&gt;&gt;comboTuneMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboTuneMode.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1285,7 +1285,7 @@
     <value>chkX2TR</value>
   </data>
   <data name="&gt;&gt;chkX2TR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkX2TR.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -1330,7 +1330,7 @@
     <value>chkFWCATU</value>
   </data>
   <data name="&gt;&gt;chkFWCATU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFWCATU.Parent" xml:space="preserve">
     <value>panelDisplay2</value>
@@ -1399,7 +1399,7 @@
     <value>comboRX2Band</value>
   </data>
   <data name="&gt;&gt;comboRX2Band.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2Band.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -1444,7 +1444,7 @@
     <value>chkRX2Preamp</value>
   </data>
   <data name="&gt;&gt;chkRX2Preamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2Preamp.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -1483,7 +1483,7 @@
     <value>chkPower</value>
   </data>
   <data name="&gt;&gt;chkPower.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkPower.Parent" xml:space="preserve">
     <value>panelPower</value>
@@ -1519,7 +1519,7 @@
     <value>ptbCWSpeed</value>
   </data>
   <data name="&gt;&gt;ptbCWSpeed.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCWSpeed.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -1543,7 +1543,7 @@
     <value>udCWPitch</value>
   </data>
   <data name="&gt;&gt;udCWPitch.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udCWPitch.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -1570,7 +1570,7 @@
     <value>udCWBreakInDelay</value>
   </data>
   <data name="&gt;&gt;udCWBreakInDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udCWBreakInDelay.Parent" xml:space="preserve">
     <value>grpSemiBreakIn</value>
@@ -1603,7 +1603,7 @@
     <value>chkShowTXCWFreq</value>
   </data>
   <data name="&gt;&gt;chkShowTXCWFreq.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkShowTXCWFreq.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -1639,7 +1639,7 @@
     <value>chkCWIambic</value>
   </data>
   <data name="&gt;&gt;chkCWIambic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCWIambic.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -1666,7 +1666,7 @@
     <value>udRX2FilterHigh</value>
   </data>
   <data name="&gt;&gt;udRX2FilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRX2FilterHigh.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -1693,7 +1693,7 @@
     <value>udRX2FilterLow</value>
   </data>
   <data name="&gt;&gt;udRX2FilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRX2FilterLow.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -1738,7 +1738,7 @@
     <value>radRX2ModeAM</value>
   </data>
   <data name="&gt;&gt;radRX2ModeAM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeAM.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1783,7 +1783,7 @@
     <value>radRX2ModeLSB</value>
   </data>
   <data name="&gt;&gt;radRX2ModeLSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeLSB.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1828,7 +1828,7 @@
     <value>radRX2ModeSAM</value>
   </data>
   <data name="&gt;&gt;radRX2ModeSAM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeSAM.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1873,7 +1873,7 @@
     <value>radRX2ModeCWL</value>
   </data>
   <data name="&gt;&gt;radRX2ModeCWL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeCWL.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1918,7 +1918,7 @@
     <value>radRX2ModeDSB</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDSB.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1963,7 +1963,7 @@
     <value>radRX2ModeUSB</value>
   </data>
   <data name="&gt;&gt;radRX2ModeUSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeUSB.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2008,7 +2008,7 @@
     <value>radRX2ModeCWU</value>
   </data>
   <data name="&gt;&gt;radRX2ModeCWU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeCWU.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2053,7 +2053,7 @@
     <value>radRX2ModeFMN</value>
   </data>
   <data name="&gt;&gt;radRX2ModeFMN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeFMN.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2098,7 +2098,7 @@
     <value>radRX2ModeDIGU</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDIGU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDIGU.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2143,7 +2143,7 @@
     <value>radRX2ModeDRM</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDRM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDRM.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2188,7 +2188,7 @@
     <value>radRX2ModeDIGL</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDIGL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDIGL.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2233,7 +2233,7 @@
     <value>radRX2ModeSPEC</value>
   </data>
   <data name="&gt;&gt;radRX2ModeSPEC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeSPEC.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2278,7 +2278,7 @@
     <value>chkRX2DisplayPeak</value>
   </data>
   <data name="&gt;&gt;chkRX2DisplayPeak.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2DisplayPeak.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -2317,7 +2317,7 @@
     <value>comboRX2DisplayMode</value>
   </data>
   <data name="&gt;&gt;comboRX2DisplayMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2DisplayMode.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -2362,7 +2362,7 @@
     <value>chkPanSwap</value>
   </data>
   <data name="&gt;&gt;chkPanSwap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkPanSwap.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -2407,7 +2407,7 @@
     <value>chkEnableMultiRX</value>
   </data>
   <data name="&gt;&gt;chkEnableMultiRX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkEnableMultiRX.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -2449,7 +2449,7 @@
     <value>chkDisplayPeak</value>
   </data>
   <data name="&gt;&gt;chkDisplayPeak.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkDisplayPeak.Parent" xml:space="preserve">
     <value>panelDisplay2</value>
@@ -2482,7 +2482,7 @@
     <value>comboDisplayMode</value>
   </data>
   <data name="&gt;&gt;comboDisplayMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboDisplayMode.Parent" xml:space="preserve">
     <value>panelDisplay2</value>
@@ -2524,7 +2524,7 @@
     <value>chkDisplayAVG</value>
   </data>
   <data name="&gt;&gt;chkDisplayAVG.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkDisplayAVG.Parent" xml:space="preserve">
     <value>panelDisplay2</value>
@@ -2569,7 +2569,7 @@
     <value>chkNR</value>
   </data>
   <data name="&gt;&gt;chkNR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkNR.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2617,7 +2617,7 @@
     <value>chkDSPNB2</value>
   </data>
   <data name="&gt;&gt;chkDSPNB2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkDSPNB2.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2662,7 +2662,7 @@
     <value>chkBIN</value>
   </data>
   <data name="&gt;&gt;chkBIN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkBIN.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2707,7 +2707,7 @@
     <value>chkNB</value>
   </data>
   <data name="&gt;&gt;chkNB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkNB.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2752,7 +2752,7 @@
     <value>chkANF</value>
   </data>
   <data name="&gt;&gt;chkANF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkANF.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2791,7 +2791,7 @@
     <value>btnZeroBeat</value>
   </data>
   <data name="&gt;&gt;btnZeroBeat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnZeroBeat.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2836,7 +2836,7 @@
     <value>chkVFOSplit</value>
   </data>
   <data name="&gt;&gt;chkVFOSplit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOSplit.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2872,7 +2872,7 @@
     <value>btnRITReset</value>
   </data>
   <data name="&gt;&gt;btnRITReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnRITReset.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2908,7 +2908,7 @@
     <value>btnXITReset</value>
   </data>
   <data name="&gt;&gt;btnXITReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnXITReset.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2932,7 +2932,7 @@
     <value>udRIT</value>
   </data>
   <data name="&gt;&gt;udRIT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRIT.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2971,7 +2971,7 @@
     <value>btnIFtoVFO</value>
   </data>
   <data name="&gt;&gt;btnIFtoVFO.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnIFtoVFO.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3013,7 +3013,7 @@
     <value>chkRIT</value>
   </data>
   <data name="&gt;&gt;chkRIT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRIT.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3052,7 +3052,7 @@
     <value>btnVFOSwap</value>
   </data>
   <data name="&gt;&gt;btnVFOSwap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnVFOSwap.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3094,7 +3094,7 @@
     <value>chkXIT</value>
   </data>
   <data name="&gt;&gt;chkXIT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkXIT.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3133,7 +3133,7 @@
     <value>btnVFOBtoA</value>
   </data>
   <data name="&gt;&gt;btnVFOBtoA.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnVFOBtoA.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3157,7 +3157,7 @@
     <value>udXIT</value>
   </data>
   <data name="&gt;&gt;udXIT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udXIT.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3196,7 +3196,7 @@
     <value>btnVFOAtoB</value>
   </data>
   <data name="&gt;&gt;btnVFOAtoB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnVFOAtoB.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3244,7 +3244,7 @@
     <value>chkRX1Preamp</value>
   </data>
   <data name="&gt;&gt;chkRX1Preamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX1Preamp.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -3271,7 +3271,7 @@
     <value>comboAGC</value>
   </data>
   <data name="&gt;&gt;comboAGC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboAGC.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -3307,7 +3307,7 @@
     <value>lblAGC</value>
   </data>
   <data name="&gt;&gt;lblAGC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAGC.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -3334,7 +3334,7 @@
     <value>comboPreamp</value>
   </data>
   <data name="&gt;&gt;comboPreamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboPreamp.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -3370,7 +3370,7 @@
     <value>lblRF</value>
   </data>
   <data name="&gt;&gt;lblRF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -3415,7 +3415,7 @@
     <value>chkShowTXFilter</value>
   </data>
   <data name="&gt;&gt;chkShowTXFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkShowTXFilter.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3463,7 +3463,7 @@
     <value>chkDX</value>
   </data>
   <data name="&gt;&gt;chkDX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkDX.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -3508,7 +3508,7 @@
     <value>chkTXEQ</value>
   </data>
   <data name="&gt;&gt;chkTXEQ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkTXEQ.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3535,7 +3535,7 @@
     <value>comboTXProfile</value>
   </data>
   <data name="&gt;&gt;comboTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3580,7 +3580,7 @@
     <value>chkRXEQ</value>
   </data>
   <data name="&gt;&gt;chkRXEQ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRXEQ.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3625,7 +3625,7 @@
     <value>chkCPDR</value>
   </data>
   <data name="&gt;&gt;chkCPDR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCPDR.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3670,7 +3670,7 @@
     <value>chkVAC1</value>
   </data>
   <data name="&gt;&gt;chkVAC1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVAC1.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3715,7 +3715,7 @@
     <value>chkVOX</value>
   </data>
   <data name="&gt;&gt;chkVOX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVOX.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3760,7 +3760,7 @@
     <value>chkNoiseGate</value>
   </data>
   <data name="&gt;&gt;chkNoiseGate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkNoiseGate.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3787,7 +3787,7 @@
     <value>comboDigTXProfile</value>
   </data>
   <data name="&gt;&gt;comboDigTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboDigTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -3820,7 +3820,7 @@
     <value>chkVACStereo</value>
   </data>
   <data name="&gt;&gt;chkVACStereo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVACStereo.Parent" xml:space="preserve">
     <value>grpVACStereo</value>
@@ -3877,7 +3877,7 @@
     <value>comboVACSampleRate</value>
   </data>
   <data name="&gt;&gt;comboVACSampleRate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboVACSampleRate.Parent" xml:space="preserve">
     <value>grpDIGSampleRate</value>
@@ -3925,7 +3925,7 @@
     <value>btnDisplayPanCenter</value>
   </data>
   <data name="&gt;&gt;btnDisplayPanCenter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnDisplayPanCenter.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -3970,7 +3970,7 @@
     <value>radModeAM</value>
   </data>
   <data name="&gt;&gt;radModeAM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeAM.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4015,7 +4015,7 @@
     <value>radModeLSB</value>
   </data>
   <data name="&gt;&gt;radModeLSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeLSB.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4060,7 +4060,7 @@
     <value>radModeSAM</value>
   </data>
   <data name="&gt;&gt;radModeSAM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeSAM.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4105,7 +4105,7 @@
     <value>radModeCWL</value>
   </data>
   <data name="&gt;&gt;radModeCWL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeCWL.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4150,7 +4150,7 @@
     <value>radModeDSB</value>
   </data>
   <data name="&gt;&gt;radModeDSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeDSB.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4195,7 +4195,7 @@
     <value>radModeUSB</value>
   </data>
   <data name="&gt;&gt;radModeUSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeUSB.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4240,7 +4240,7 @@
     <value>radModeCWU</value>
   </data>
   <data name="&gt;&gt;radModeCWU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeCWU.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4285,7 +4285,7 @@
     <value>radModeFMN</value>
   </data>
   <data name="&gt;&gt;radModeFMN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeFMN.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4330,7 +4330,7 @@
     <value>radModeDIGU</value>
   </data>
   <data name="&gt;&gt;radModeDIGU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeDIGU.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4375,7 +4375,7 @@
     <value>radModeDRM</value>
   </data>
   <data name="&gt;&gt;radModeDRM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeDRM.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4420,7 +4420,7 @@
     <value>radModeDIGL</value>
   </data>
   <data name="&gt;&gt;radModeDIGL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeDIGL.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4465,7 +4465,7 @@
     <value>radModeSPEC</value>
   </data>
   <data name="&gt;&gt;radModeSPEC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeSPEC.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4504,7 +4504,7 @@
     <value>btnBandVHF</value>
   </data>
   <data name="&gt;&gt;btnBandVHF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnBandVHF.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -4546,7 +4546,7 @@
     <value>chkVFOATX</value>
   </data>
   <data name="&gt;&gt;chkVFOATX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOATX.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -4576,7 +4576,7 @@
     <value>txtWheelTune</value>
   </data>
   <data name="&gt;&gt;txtWheelTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtWheelTune.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4618,7 +4618,7 @@
     <value>chkVFOBTX</value>
   </data>
   <data name="&gt;&gt;chkVFOBTX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOBTX.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -4648,7 +4648,7 @@
     <value>comboMeterTXMode</value>
   </data>
   <data name="&gt;&gt;comboMeterTXMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboMeterTXMode.Parent" xml:space="preserve">
     <value>grpMultimeterMenus</value>
@@ -4675,7 +4675,7 @@
     <value>comboMeterRXMode</value>
   </data>
   <data name="&gt;&gt;comboMeterRXMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboMeterRXMode.Parent" xml:space="preserve">
     <value>grpMultimeterMenus</value>
@@ -4717,7 +4717,7 @@
     <value>chkSquelch</value>
   </data>
   <data name="&gt;&gt;chkSquelch.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkSquelch.Parent" xml:space="preserve">
     <value>$this</value>
@@ -4756,7 +4756,7 @@
     <value>btnMemoryQuickRestore</value>
   </data>
   <data name="&gt;&gt;btnMemoryQuickRestore.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnMemoryQuickRestore.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4798,7 +4798,7 @@
     <value>btnMemoryQuickSave</value>
   </data>
   <data name="&gt;&gt;btnMemoryQuickSave.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnMemoryQuickSave.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4825,7 +4825,7 @@
     <value>txtMemoryQuick</value>
   </data>
   <data name="&gt;&gt;txtMemoryQuick.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtMemoryQuick.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4873,7 +4873,7 @@
     <value>chkVFOLock</value>
   </data>
   <data name="&gt;&gt;chkVFOLock.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOLock.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4918,7 +4918,7 @@
     <value>chkVFOSync</value>
   </data>
   <data name="&gt;&gt;chkVFOSync.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOSync.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4957,7 +4957,7 @@
     <value>btnTuneStepChangeLarger</value>
   </data>
   <data name="&gt;&gt;btnTuneStepChangeLarger.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnTuneStepChangeLarger.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4996,7 +4996,7 @@
     <value>btnTuneStepChangeSmaller</value>
   </data>
   <data name="&gt;&gt;btnTuneStepChangeSmaller.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnTuneStepChangeSmaller.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -5035,7 +5035,7 @@
     <value>chkSplitDisplay</value>
   </data>
   <data name="&gt;&gt;chkSplitDisplay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkSplitDisplay.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -5071,7 +5071,7 @@
     <value>comboDisplayModeTop</value>
   </data>
   <data name="&gt;&gt;comboDisplayModeTop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboDisplayModeTop.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -5107,7 +5107,7 @@
     <value>comboDisplayModeBottom</value>
   </data>
   <data name="&gt;&gt;comboDisplayModeBottom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboDisplayModeBottom.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -5134,7 +5134,7 @@
     <value>comboRX2MeterMode</value>
   </data>
   <data name="&gt;&gt;comboRX2MeterMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2MeterMode.Parent" xml:space="preserve">
     <value>grpRX2Meter</value>
@@ -5179,7 +5179,7 @@
     <value>chkRX2DisplayAVG</value>
   </data>
   <data name="&gt;&gt;chkRX2DisplayAVG.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2DisplayAVG.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -5224,7 +5224,7 @@
     <value>radBand160</value>
   </data>
   <data name="&gt;&gt;radBand160.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand160.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5270,7 +5270,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBandGEN</value>
   </data>
   <data name="&gt;&gt;radBandGEN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5315,7 +5315,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBandWWV</value>
   </data>
   <data name="&gt;&gt;radBandWWV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandWWV.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5363,7 +5363,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand2</value>
   </data>
   <data name="&gt;&gt;radBand2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand2.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5408,7 +5408,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand6</value>
   </data>
   <data name="&gt;&gt;radBand6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand6.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5453,7 +5453,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand10</value>
   </data>
   <data name="&gt;&gt;radBand10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand10.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5498,7 +5498,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand12</value>
   </data>
   <data name="&gt;&gt;radBand12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand12.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5543,7 +5543,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand15</value>
   </data>
   <data name="&gt;&gt;radBand15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand15.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5588,7 +5588,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand17</value>
   </data>
   <data name="&gt;&gt;radBand17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand17.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5633,7 +5633,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand20</value>
   </data>
   <data name="&gt;&gt;radBand20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand20.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5678,7 +5678,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand30</value>
   </data>
   <data name="&gt;&gt;radBand30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand30.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5723,7 +5723,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand40</value>
   </data>
   <data name="&gt;&gt;radBand40.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand40.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5768,7 +5768,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand60</value>
   </data>
   <data name="&gt;&gt;radBand60.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand60.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5813,7 +5813,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand80</value>
   </data>
   <data name="&gt;&gt;radBand80.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand80.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5852,7 +5852,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbDisplayZoom</value>
   </data>
   <data name="&gt;&gt;ptbDisplayZoom.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbDisplayZoom.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -5891,7 +5891,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbDisplayPan</value>
   </data>
   <data name="&gt;&gt;ptbDisplayPan.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbDisplayPan.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -5927,7 +5927,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbPWR</value>
   </data>
   <data name="&gt;&gt;ptbPWR.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbPWR.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -5963,7 +5963,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRF</value>
   </data>
   <data name="&gt;&gt;ptbRF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -5999,7 +5999,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbAF</value>
   </data>
   <data name="&gt;&gt;ptbAF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbAF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -6035,7 +6035,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbPanMainRX</value>
   </data>
   <data name="&gt;&gt;ptbPanMainRX.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbPanMainRX.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -6071,7 +6071,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbPanSubRX</value>
   </data>
   <data name="&gt;&gt;ptbPanSubRX.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbPanSubRX.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -6104,7 +6104,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX2Gain</value>
   </data>
   <data name="&gt;&gt;ptbRX2Gain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2Gain.Parent" xml:space="preserve">
     <value>panelRX2Mixer</value>
@@ -6137,7 +6137,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX2Pan</value>
   </data>
   <data name="&gt;&gt;ptbRX2Pan.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2Pan.Parent" xml:space="preserve">
     <value>panelRX2Mixer</value>
@@ -6170,7 +6170,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX0Gain</value>
   </data>
   <data name="&gt;&gt;ptbRX0Gain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX0Gain.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -6203,7 +6203,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX1Gain</value>
   </data>
   <data name="&gt;&gt;ptbRX1Gain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX1Gain.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -6236,7 +6236,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbVACRXGain</value>
   </data>
   <data name="&gt;&gt;ptbVACRXGain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbVACRXGain.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -6269,7 +6269,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbVACTXGain</value>
   </data>
   <data name="&gt;&gt;ptbVACTXGain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbVACTXGain.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -6320,7 +6320,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radDisplayZoom05</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom05.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom05.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -6371,7 +6371,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radDisplayZoom4x</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom4x.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom4x.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -6422,7 +6422,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radDisplayZoom2x</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom2x.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom2x.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -6473,7 +6473,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radDisplayZoom1x</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom1x.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom1x.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -6518,7 +6518,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkMicMute</value>
   </data>
   <data name="&gt;&gt;chkMicMute.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkMicMute.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -6563,7 +6563,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkMUT</value>
   </data>
   <data name="&gt;&gt;chkMUT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkMUT.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -6602,7 +6602,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkCWFWKeyer</value>
   </data>
   <data name="&gt;&gt;chkCWFWKeyer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCWFWKeyer.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -6638,7 +6638,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkShowCWZero</value>
   </data>
   <data name="&gt;&gt;chkShowCWZero.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkShowCWZero.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -6683,7 +6683,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radFMDeviation5kHz</value>
   </data>
   <data name="&gt;&gt;radFMDeviation5kHz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFMDeviation5kHz.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6710,7 +6710,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>comboFMTXProfile</value>
   </data>
   <data name="&gt;&gt;comboFMTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboFMTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6734,7 +6734,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>udFMOffset</value>
   </data>
   <data name="&gt;&gt;udFMOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udFMOffset.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6779,7 +6779,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMTXSimplex</value>
   </data>
   <data name="&gt;&gt;chkFMTXSimplex.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMTXSimplex.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6803,7 +6803,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>comboFMCTCSS</value>
   </data>
   <data name="&gt;&gt;comboFMCTCSS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboFMCTCSS.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6842,7 +6842,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>btnFMMemory</value>
   </data>
   <data name="&gt;&gt;btnFMMemory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnFMMemory.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6887,7 +6887,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMCTCSS</value>
   </data>
   <data name="&gt;&gt;chkFMCTCSS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMCTCSS.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6929,7 +6929,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>btnFMMemoryUp</value>
   </data>
   <data name="&gt;&gt;btnFMMemoryUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnFMMemoryUp.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6971,7 +6971,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>btnFMMemoryDown</value>
   </data>
   <data name="&gt;&gt;btnFMMemoryDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnFMMemoryDown.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7016,7 +7016,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radFMDeviation2kHz</value>
   </data>
   <data name="&gt;&gt;radFMDeviation2kHz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFMDeviation2kHz.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7061,7 +7061,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMTXLow</value>
   </data>
   <data name="&gt;&gt;chkFMTXLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMTXLow.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7106,7 +7106,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMTXHigh</value>
   </data>
   <data name="&gt;&gt;chkFMTXHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMTXHigh.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7154,7 +7154,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMTXRev</value>
   </data>
   <data name="&gt;&gt;chkFMTXRev.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMTXRev.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7199,7 +7199,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkTNF</value>
   </data>
   <data name="&gt;&gt;chkTNF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkTNF.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -7238,7 +7238,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>btnTNFAdd</value>
   </data>
   <data name="&gt;&gt;btnTNFAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnTNFAdd.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -7274,7 +7274,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX2AF</value>
   </data>
   <data name="&gt;&gt;ptbRX2AF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2AF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -7310,7 +7310,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX1AF</value>
   </data>
   <data name="&gt;&gt;ptbRX1AF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX1AF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -7352,7 +7352,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkVAC2</value>
   </data>
   <data name="&gt;&gt;chkVAC2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVAC2.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -7385,7 +7385,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkCWSidetone</value>
   </data>
   <data name="&gt;&gt;chkCWSidetone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCWSidetone.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -7412,7 +7412,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>udRX1StepAttData</value>
   </data>
   <data name="&gt;&gt;udRX1StepAttData.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRX1StepAttData.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -7439,7 +7439,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>comboRX2Preamp</value>
   </data>
   <data name="&gt;&gt;comboRX2Preamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2Preamp.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -7466,7 +7466,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>udRX2StepAttData</value>
   </data>
   <data name="&gt;&gt;udRX2StepAttData.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRX2StepAttData.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -7511,7 +7511,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkCWAPFEnabled</value>
   </data>
   <data name="&gt;&gt;chkCWAPFEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCWAPFEnabled.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -7547,7 +7547,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbCWAPFGain</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFGain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFGain.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -7583,7 +7583,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbCWAPFBandwidth</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFBandwidth.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFBandwidth.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -7619,7 +7619,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbCWAPFFreq</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFFreq.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFFreq.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -7656,7 +7656,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>lblBandStack</value>
   </data>
   <data name="&gt;&gt;lblBandStack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblBandStack.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -7689,7 +7689,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>regBandStackCurrentEntry</value>
   </data>
   <data name="&gt;&gt;regBandStackCurrentEntry.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;regBandStackCurrentEntry.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -7723,7 +7723,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>regBandStackTotalEntries</value>
   </data>
   <data name="&gt;&gt;regBandStackTotalEntries.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;regBandStackTotalEntries.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -7771,7 +7771,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN13</value>
   </data>
   <data name="&gt;&gt;radBandGEN13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN13.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -7819,7 +7819,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN12</value>
   </data>
   <data name="&gt;&gt;radBandGEN12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN12.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -7867,7 +7867,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN11</value>
   </data>
   <data name="&gt;&gt;radBandGEN11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN11.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -7915,7 +7915,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN10</value>
   </data>
   <data name="&gt;&gt;radBandGEN10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN10.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -7963,7 +7963,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN9</value>
   </data>
   <data name="&gt;&gt;radBandGEN9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN9.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8011,7 +8011,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN8</value>
   </data>
   <data name="&gt;&gt;radBandGEN8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN8.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8059,7 +8059,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN7</value>
   </data>
   <data name="&gt;&gt;radBandGEN7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN7.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8107,7 +8107,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN6</value>
   </data>
   <data name="&gt;&gt;radBandGEN6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN6.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8155,7 +8155,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN5</value>
   </data>
   <data name="&gt;&gt;radBandGEN5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN5.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8203,7 +8203,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN4</value>
   </data>
   <data name="&gt;&gt;radBandGEN4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN4.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8251,7 +8251,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN3</value>
   </data>
   <data name="&gt;&gt;radBandGEN3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN3.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8299,7 +8299,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN2</value>
   </data>
   <data name="&gt;&gt;radBandGEN2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN2.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8347,7 +8347,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN1</value>
   </data>
   <data name="&gt;&gt;radBandGEN1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN1.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8395,7 +8395,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN0</value>
   </data>
   <data name="&gt;&gt;radBandGEN0.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN0.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8422,7 +8422,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>udTXFilterLow</value>
   </data>
   <data name="&gt;&gt;udTXFilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udTXFilterLow.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -8449,7 +8449,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>udTXFilterHigh</value>
   </data>
   <data name="&gt;&gt;udTXFilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udTXFilterHigh.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -8494,7 +8494,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>chkRxAnt</value>
   </data>
   <data name="&gt;&gt;chkRxAnt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRxAnt.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -8542,7 +8542,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>chkVFOBLock</value>
   </data>
   <data name="&gt;&gt;chkVFOBLock.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOBLock.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -8587,7 +8587,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>chkQSK</value>
   </data>
   <data name="&gt;&gt;chkQSK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkQSK.Parent" xml:space="preserve">
     <value>grpSemiBreakIn</value>
@@ -8614,7 +8614,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>comboAMTXProfile</value>
   </data>
   <data name="&gt;&gt;comboAMTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboAMTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -8659,7 +8659,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnDisplayZTB</value>
   </data>
   <data name="&gt;&gt;btnDisplayZTB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnDisplayZTB.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -8695,7 +8695,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbTune</value>
   </data>
   <data name="&gt;&gt;ptbTune.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbTune.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -9987,7 +9987,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>None</value>
   </data>
   <data name="toolStripStatusLabel_Fill.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 15</value>
+    <value>204, 15</value>
   </data>
   <data name="toolStripStatusLabel_N1MMActive.AutoSize" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -10119,7 +10119,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>pnlResizeMeter</value>
   </data>
   <data name="&gt;&gt;pnlResizeMeter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pnlResizeMeter.Parent" xml:space="preserve">
     <value>grpMultimeter</value>
@@ -10176,7 +10176,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtMultiText</value>
   </data>
   <data name="&gt;&gt;txtMultiText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtMultiText.Parent" xml:space="preserve">
     <value>grpMultimeter</value>
@@ -10200,7 +10200,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpMultimeter</value>
   </data>
   <data name="&gt;&gt;grpMultimeter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpMultimeter.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10248,7 +10248,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter1</value>
   </data>
   <data name="&gt;&gt;radFilter1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter1.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10281,7 +10281,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterHigh</value>
   </data>
   <data name="&gt;&gt;lblFilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterHigh.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10311,7 +10311,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterWidth</value>
   </data>
   <data name="&gt;&gt;lblFilterWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterWidth.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10353,7 +10353,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilterVar2</value>
   </data>
   <data name="&gt;&gt;radFilterVar2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilterVar2.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10386,7 +10386,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterLow</value>
   </data>
   <data name="&gt;&gt;lblFilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterLow.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10428,7 +10428,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilterVar1</value>
   </data>
   <data name="&gt;&gt;radFilterVar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilterVar1.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10458,7 +10458,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterShift</value>
   </data>
   <data name="&gt;&gt;lblFilterShift.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterShift.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10500,7 +10500,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter9</value>
   </data>
   <data name="&gt;&gt;radFilter9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter9.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10542,7 +10542,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter8</value>
   </data>
   <data name="&gt;&gt;radFilter8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter8.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10584,7 +10584,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter2</value>
   </data>
   <data name="&gt;&gt;radFilter2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter2.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10626,7 +10626,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter7</value>
   </data>
   <data name="&gt;&gt;radFilter7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter7.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10668,7 +10668,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter3</value>
   </data>
   <data name="&gt;&gt;radFilter3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter3.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10710,7 +10710,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter6</value>
   </data>
   <data name="&gt;&gt;radFilter6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter6.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10752,7 +10752,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter4</value>
   </data>
   <data name="&gt;&gt;radFilter4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter4.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10794,7 +10794,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter5</value>
   </data>
   <data name="&gt;&gt;radFilter5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter5.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10836,7 +10836,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter10</value>
   </data>
   <data name="&gt;&gt;radFilter10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter10.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10860,7 +10860,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelFilter</value>
   </data>
   <data name="&gt;&gt;panelFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelFilter.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10887,7 +10887,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2RF</value>
   </data>
   <data name="&gt;&gt;panelRX2RF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2RF.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10920,7 +10920,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbRX2Squelch</value>
   </data>
   <data name="&gt;&gt;ptbRX2Squelch.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2Squelch.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10947,7 +10947,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2DSP</value>
   </data>
   <data name="&gt;&gt;panelRX2DSP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2DSP.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10977,7 +10977,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnHidden</value>
   </data>
   <data name="&gt;&gt;btnHidden.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnHidden.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11028,7 +11028,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>checkBoxTS1</value>
   </data>
   <data name="&gt;&gt;checkBoxTS1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;checkBoxTS1.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -11052,7 +11052,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelOptions</value>
   </data>
   <data name="&gt;&gt;panelOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelOptions.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11091,7 +11091,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar8</value>
   </data>
   <data name="&gt;&gt;btnAndrBar8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar8.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11124,7 +11124,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar7</value>
   </data>
   <data name="&gt;&gt;btnAndrBar7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar7.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11157,7 +11157,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar6</value>
   </data>
   <data name="&gt;&gt;btnAndrBar6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar6.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11190,7 +11190,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar5</value>
   </data>
   <data name="&gt;&gt;btnAndrBar5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar5.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11223,7 +11223,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar4</value>
   </data>
   <data name="&gt;&gt;btnAndrBar4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar4.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11256,7 +11256,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar3</value>
   </data>
   <data name="&gt;&gt;btnAndrBar3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar3.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11289,7 +11289,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar2</value>
   </data>
   <data name="&gt;&gt;btnAndrBar2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar2.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11322,7 +11322,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar1</value>
   </data>
   <data name="&gt;&gt;btnAndrBar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar1.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11346,7 +11346,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelButtonBar</value>
   </data>
   <data name="&gt;&gt;panelButtonBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelButtonBar.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11385,7 +11385,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblStepValue</value>
   </data>
   <data name="&gt;&gt;lblStepValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblStepValue.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11418,7 +11418,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblStep</value>
   </data>
   <data name="&gt;&gt;lblStep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblStep.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11454,7 +11454,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVFOSplit</value>
   </data>
   <data name="&gt;&gt;lblVFOSplit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVFOSplit.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11487,7 +11487,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblXITValue</value>
   </data>
   <data name="&gt;&gt;lblXITValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblXITValue.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11520,7 +11520,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRITValue</value>
   </data>
   <data name="&gt;&gt;lblRITValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRITValue.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11553,7 +11553,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRITLabel</value>
   </data>
   <data name="&gt;&gt;lblRITLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRITLabel.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11586,7 +11586,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblXITLabel</value>
   </data>
   <data name="&gt;&gt;lblXITLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblXITLabel.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11622,7 +11622,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVFOSyncLabel</value>
   </data>
   <data name="&gt;&gt;lblVFOSyncLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVFOSyncLabel.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11646,7 +11646,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelVFOLabels</value>
   </data>
   <data name="&gt;&gt;panelVFOLabels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelVFOLabels.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11688,7 +11688,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblLockLabel</value>
   </data>
   <data name="&gt;&gt;lblLockLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblLockLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11724,7 +11724,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAGCLabel</value>
   </data>
   <data name="&gt;&gt;lblAGCLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAGCLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11760,7 +11760,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAttenLabel</value>
   </data>
   <data name="&gt;&gt;lblAttenLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAttenLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11793,7 +11793,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblANFLabel</value>
   </data>
   <data name="&gt;&gt;lblANFLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblANFLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11826,7 +11826,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblSNBLabel</value>
   </data>
   <data name="&gt;&gt;lblSNBLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblSNBLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11859,7 +11859,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblNBLabel</value>
   </data>
   <data name="&gt;&gt;lblNBLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblNBLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11892,7 +11892,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblNRLabel</value>
   </data>
   <data name="&gt;&gt;lblNRLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblNRLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11928,7 +11928,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCtunLabel</value>
   </data>
   <data name="&gt;&gt;lblCtunLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCtunLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11952,7 +11952,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelVFOALabels</value>
   </data>
   <data name="&gt;&gt;panelVFOALabels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelVFOALabels.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11994,7 +11994,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2AttenLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2AttenLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2AttenLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12030,7 +12030,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2LockLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2LockLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2LockLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12066,7 +12066,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2AGCLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2AGCLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2AGCLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12102,7 +12102,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2CtunLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2CtunLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2CtunLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12135,7 +12135,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2NRLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2NRLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2NRLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12168,7 +12168,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2NBLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2NBLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2NBLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12201,7 +12201,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2SNBLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2SNBLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2SNBLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12234,7 +12234,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2ANFLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2ANFLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2ANFLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12258,7 +12258,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelVFOBLabels</value>
   </data>
   <data name="&gt;&gt;panelVFOBLabels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelVFOBLabels.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12297,7 +12297,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2Band</value>
   </data>
   <data name="&gt;&gt;lblRX2Band.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2Band.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -12330,7 +12330,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2Preamp</value>
   </data>
   <data name="&gt;&gt;lblRX2Preamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2Preamp.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -12351,7 +12351,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Power</value>
   </data>
   <data name="&gt;&gt;panelRX2Power.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Power.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12387,7 +12387,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>chkRX2</value>
   </data>
   <data name="&gt;&gt;chkRX2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2.Parent" xml:space="preserve">
     <value>panelPower</value>
@@ -12420,7 +12420,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX1Show</value>
   </data>
   <data name="&gt;&gt;radRX1Show.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX1Show.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -12456,7 +12456,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Show</value>
   </data>
   <data name="&gt;&gt;radRX2Show.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Show.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -12492,7 +12492,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRF2</value>
   </data>
   <data name="&gt;&gt;lblRF2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRF2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12519,7 +12519,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelPower</value>
   </data>
   <data name="&gt;&gt;panelPower.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelPower.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12555,7 +12555,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWAPFGain</value>
   </data>
   <data name="&gt;&gt;lblCWAPFGain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWAPFGain.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -12585,7 +12585,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWAPFBandwidth</value>
   </data>
   <data name="&gt;&gt;lblCWAPFBandwidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWAPFBandwidth.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -12615,7 +12615,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWAPFTune</value>
   </data>
   <data name="&gt;&gt;lblCWAPFTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWAPFTune.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -12639,7 +12639,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpCWAPF</value>
   </data>
   <data name="&gt;&gt;grpCWAPF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpCWAPF.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -12669,7 +12669,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWSpeed</value>
   </data>
   <data name="&gt;&gt;lblCWSpeed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWSpeed.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -12699,7 +12699,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWBreakInDelay</value>
   </data>
   <data name="&gt;&gt;lblCWBreakInDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWBreakInDelay.Parent" xml:space="preserve">
     <value>grpSemiBreakIn</value>
@@ -12723,7 +12723,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpSemiBreakIn</value>
   </data>
   <data name="&gt;&gt;grpSemiBreakIn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpSemiBreakIn.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -12753,7 +12753,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWPitchFreq</value>
   </data>
   <data name="&gt;&gt;lblCWPitchFreq.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWPitchFreq.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -12774,7 +12774,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelModeSpecificCW</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificCW.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificCW.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12822,7 +12822,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter1</value>
   </data>
   <data name="&gt;&gt;radRX2Filter1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter1.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -12855,7 +12855,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2FilterHigh</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterHigh.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -12888,7 +12888,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2FilterLow</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterLow.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -12930,7 +12930,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter2</value>
   </data>
   <data name="&gt;&gt;radRX2Filter2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter2.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -12972,7 +12972,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2FilterVar2</value>
   </data>
   <data name="&gt;&gt;radRX2FilterVar2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2FilterVar2.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13014,7 +13014,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter3</value>
   </data>
   <data name="&gt;&gt;radRX2Filter3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter3.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13056,7 +13056,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2FilterVar1</value>
   </data>
   <data name="&gt;&gt;radRX2FilterVar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2FilterVar1.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13098,7 +13098,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter4</value>
   </data>
   <data name="&gt;&gt;radRX2Filter4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter4.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13140,7 +13140,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter7</value>
   </data>
   <data name="&gt;&gt;radRX2Filter7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter7.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13182,7 +13182,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter5</value>
   </data>
   <data name="&gt;&gt;radRX2Filter5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter5.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13224,7 +13224,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter6</value>
   </data>
   <data name="&gt;&gt;radRX2Filter6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter6.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13245,7 +13245,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Filter</value>
   </data>
   <data name="&gt;&gt;panelRX2Filter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Filter.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13272,7 +13272,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Mode</value>
   </data>
   <data name="&gt;&gt;panelRX2Mode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Mode.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13299,7 +13299,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Display</value>
   </data>
   <data name="&gt;&gt;panelRX2Display.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Display.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13386,7 +13386,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Mixer</value>
   </data>
   <data name="&gt;&gt;panelRX2Mixer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Mixer.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13503,7 +13503,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelMultiRX</value>
   </data>
   <data name="&gt;&gt;panelMultiRX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelMultiRX.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13533,7 +13533,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelDisplay2</value>
   </data>
   <data name="&gt;&gt;panelDisplay2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelDisplay2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13563,7 +13563,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelDSP</value>
   </data>
   <data name="&gt;&gt;panelDSP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelDSP.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13599,7 +13599,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ucVAC2UnderOver</value>
   </data>
   <data name="&gt;&gt;ucVAC2UnderOver.Type" xml:space="preserve">
-    <value>Thetis.ucUnderOverFlowWarningViewer, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.ucUnderOverFlowWarningViewer, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ucVAC2UnderOver.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -13629,7 +13629,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ucVAC1UnderOver</value>
   </data>
   <data name="&gt;&gt;ucVAC1UnderOver.Type" xml:space="preserve">
-    <value>Thetis.ucUnderOverFlowWarningViewer, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.ucUnderOverFlowWarningViewer, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ucVAC1UnderOver.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -13653,7 +13653,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelVFO</value>
   </data>
   <data name="&gt;&gt;panelVFO.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelVFO.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13692,7 +13692,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblTune</value>
   </data>
   <data name="&gt;&gt;lblTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTune.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13725,7 +13725,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2AF</value>
   </data>
   <data name="&gt;&gt;lblRX2AF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2AF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13758,7 +13758,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX1AF</value>
   </data>
   <data name="&gt;&gt;lblRX1AF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX1AF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13791,7 +13791,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAF</value>
   </data>
   <data name="&gt;&gt;lblAF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13824,7 +13824,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblPWR</value>
   </data>
   <data name="&gt;&gt;lblPWR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblPWR.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13857,7 +13857,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblPreamp</value>
   </data>
   <data name="&gt;&gt;lblPreamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblPreamp.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13878,7 +13878,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelSoundControls</value>
   </data>
   <data name="&gt;&gt;panelSoundControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelSoundControls.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13914,7 +13914,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAF2</value>
   </data>
   <data name="&gt;&gt;lblAF2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAF2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13953,7 +13953,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblPWR2</value>
   </data>
   <data name="&gt;&gt;lblPWR2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblPWR2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13995,7 +13995,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS2</value>
   </data>
   <data name="&gt;&gt;labelTS2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS2.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14031,7 +14031,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblPAProfile</value>
   </data>
   <data name="&gt;&gt;lblPAProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblPAProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14064,7 +14064,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS4</value>
   </data>
   <data name="&gt;&gt;labelTS4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS4.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14100,7 +14100,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS3</value>
   </data>
   <data name="&gt;&gt;labelTS3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS3.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14166,7 +14166,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblNoiseGateVal</value>
   </data>
   <data name="&gt;&gt;lblNoiseGateVal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblNoiseGateVal.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14205,7 +14205,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbNoiseGate</value>
   </data>
   <data name="&gt;&gt;ptbNoiseGate.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbNoiseGate.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14262,7 +14262,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbVOX</value>
   </data>
   <data name="&gt;&gt;ptbVOX.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbVOX.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14298,7 +14298,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVOXVal</value>
   </data>
   <data name="&gt;&gt;lblVOXVal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVOXVal.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14331,7 +14331,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbCPDR</value>
   </data>
   <data name="&gt;&gt;ptbCPDR.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCPDR.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14367,7 +14367,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCPDRVal</value>
   </data>
   <data name="&gt;&gt;lblCPDRVal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCPDRVal.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14403,7 +14403,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblMicVal</value>
   </data>
   <data name="&gt;&gt;lblMicVal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblMicVal.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14436,7 +14436,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbMic</value>
   </data>
   <data name="&gt;&gt;ptbMic.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbMic.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14475,7 +14475,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblMIC</value>
   </data>
   <data name="&gt;&gt;lblMIC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblMIC.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14508,7 +14508,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblTransmitProfile</value>
   </data>
   <data name="&gt;&gt;lblTransmitProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTransmitProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14529,7 +14529,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelModeSpecificPhone</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificPhone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificPhone.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14565,7 +14565,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVACTXIndicator</value>
   </data>
   <data name="&gt;&gt;lblVACTXIndicator.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVACTXIndicator.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14595,7 +14595,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVACRXIndicator</value>
   </data>
   <data name="&gt;&gt;lblVACRXIndicator.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVACRXIndicator.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14628,7 +14628,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDigTXProfile</value>
   </data>
   <data name="&gt;&gt;lblDigTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDigTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14658,7 +14658,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRXGain</value>
   </data>
   <data name="&gt;&gt;lblRXGain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRXGain.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14682,7 +14682,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpVACStereo</value>
   </data>
   <data name="&gt;&gt;grpVACStereo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpVACStereo.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14712,7 +14712,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblTXGain</value>
   </data>
   <data name="&gt;&gt;lblTXGain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTXGain.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14736,7 +14736,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpDIGSampleRate</value>
   </data>
   <data name="&gt;&gt;grpDIGSampleRate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpDIGSampleRate.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14760,7 +14760,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelModeSpecificDigital</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificDigital.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificDigital.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14799,7 +14799,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>infoBar</value>
   </data>
   <data name="&gt;&gt;infoBar.Type" xml:space="preserve">
-    <value>Thetis.ucInfoBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.ucInfoBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;infoBar.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -14838,7 +14838,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDisplayZoom</value>
   </data>
   <data name="&gt;&gt;lblDisplayZoom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDisplayZoom.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -14877,7 +14877,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDisplayPan</value>
   </data>
   <data name="&gt;&gt;lblDisplayPan.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDisplayPan.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -14937,7 +14937,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelDisplay</value>
   </data>
   <data name="&gt;&gt;panelDisplay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelDisplay.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14970,7 +14970,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelMode</value>
   </data>
   <data name="&gt;&gt;panelMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelMode.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15000,7 +15000,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelBandHF</value>
   </data>
   <data name="&gt;&gt;panelBandHF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelBandHF.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15030,7 +15030,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOAFreq</value>
   </data>
   <data name="&gt;&gt;txtVFOAFreq.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOAFreq.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15093,7 +15093,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblModeBigLabel</value>
   </data>
   <data name="&gt;&gt;lblModeBigLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblModeBigLabel.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15129,7 +15129,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX1APF</value>
   </data>
   <data name="&gt;&gt;lblRX1APF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX1APF.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15162,7 +15162,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX1MuteVFOA</value>
   </data>
   <data name="&gt;&gt;lblRX1MuteVFOA.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX1MuteVFOA.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15204,7 +15204,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterLabel</value>
   </data>
   <data name="&gt;&gt;lblFilterLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterLabel.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15246,7 +15246,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblModeLabel</value>
   </data>
   <data name="&gt;&gt;lblModeLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblModeLabel.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15276,7 +15276,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOALSD</value>
   </data>
   <data name="&gt;&gt;txtVFOALSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOALSD.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15306,7 +15306,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOAMSD</value>
   </data>
   <data name="&gt;&gt;txtVFOAMSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOAMSD.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15360,7 +15360,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOABand</value>
   </data>
   <data name="&gt;&gt;txtVFOABand.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOABand.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15387,7 +15387,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpVFOA</value>
   </data>
   <data name="&gt;&gt;grpVFOA.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpVFOA.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15429,7 +15429,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2ModeBigLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2ModeBigLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2ModeBigLabel.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15465,7 +15465,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2APF</value>
   </data>
   <data name="&gt;&gt;lblRX2APF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2APF.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15516,7 +15516,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOBBand</value>
   </data>
   <data name="&gt;&gt;txtVFOBBand.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOBBand.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15546,7 +15546,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOBLSD</value>
   </data>
   <data name="&gt;&gt;txtVFOBLSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOBLSD.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15588,7 +15588,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2FilterLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterLabel.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15621,7 +15621,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2MuteVFOB</value>
   </data>
   <data name="&gt;&gt;lblRX2MuteVFOB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2MuteVFOB.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15663,7 +15663,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2ModeLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2ModeLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2ModeLabel.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15693,7 +15693,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOBMSD</value>
   </data>
   <data name="&gt;&gt;txtVFOBMSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOBMSD.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15735,7 +15735,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVFOBLSD</value>
   </data>
   <data name="&gt;&gt;lblVFOBLSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVFOBLSD.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15765,7 +15765,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOBFreq</value>
   </data>
   <data name="&gt;&gt;txtVFOBFreq.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOBFreq.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15792,7 +15792,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpVFOB</value>
   </data>
   <data name="&gt;&gt;grpVFOB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpVFOB.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15828,7 +15828,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnBandHF</value>
   </data>
   <data name="&gt;&gt;btnBandHF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnBandHF.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -15858,7 +15858,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblTuneStep</value>
   </data>
   <data name="&gt;&gt;lblTuneStep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTuneStep.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -15879,7 +15879,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ucQuickRecallPad</value>
   </data>
   <data name="&gt;&gt;ucQuickRecallPad.Type" xml:space="preserve">
-    <value>Thetis.ucQuickRecall, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.ucQuickRecall, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ucQuickRecallPad.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -15909,7 +15909,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS1</value>
   </data>
   <data name="&gt;&gt;labelTS1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS1.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -15930,7 +15930,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpVFOBetween</value>
   </data>
   <data name="&gt;&gt;grpVFOBetween.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpVFOBetween.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15960,7 +15960,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDisplayModeTop</value>
   </data>
   <data name="&gt;&gt;lblDisplayModeTop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDisplayModeTop.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -15990,7 +15990,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDisplayModeBottom</value>
   </data>
   <data name="&gt;&gt;lblDisplayModeBottom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDisplayModeBottom.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -16017,7 +16017,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpDisplaySplit</value>
   </data>
   <data name="&gt;&gt;grpDisplaySplit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpDisplaySplit.Parent" xml:space="preserve">
     <value>$this</value>
@@ -16074,7 +16074,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtRX2Meter</value>
   </data>
   <data name="&gt;&gt;txtRX2Meter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtRX2Meter.Parent" xml:space="preserve">
     <value>grpRX2Meter</value>
@@ -16098,7 +16098,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpRX2Meter</value>
   </data>
   <data name="&gt;&gt;grpRX2Meter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpRX2Meter.Parent" xml:space="preserve">
     <value>$this</value>
@@ -16149,7 +16149,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF13</value>
   </data>
   <data name="&gt;&gt;radBandVHF13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF13.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16194,7 +16194,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF12</value>
   </data>
   <data name="&gt;&gt;radBandVHF12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF12.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16239,7 +16239,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF11</value>
   </data>
   <data name="&gt;&gt;radBandVHF11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF11.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16284,7 +16284,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF10</value>
   </data>
   <data name="&gt;&gt;radBandVHF10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF10.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16329,7 +16329,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF9</value>
   </data>
   <data name="&gt;&gt;radBandVHF9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF9.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16374,7 +16374,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF8</value>
   </data>
   <data name="&gt;&gt;radBandVHF8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF8.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16419,7 +16419,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF7</value>
   </data>
   <data name="&gt;&gt;radBandVHF7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF7.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16464,7 +16464,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF6</value>
   </data>
   <data name="&gt;&gt;radBandVHF6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF6.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16509,7 +16509,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF5</value>
   </data>
   <data name="&gt;&gt;radBandVHF5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF5.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16554,7 +16554,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF4</value>
   </data>
   <data name="&gt;&gt;radBandVHF4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF4.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16599,7 +16599,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF3</value>
   </data>
   <data name="&gt;&gt;radBandVHF3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF3.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16644,7 +16644,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF2</value>
   </data>
   <data name="&gt;&gt;radBandVHF2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF2.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16689,7 +16689,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF1</value>
   </data>
   <data name="&gt;&gt;radBandVHF1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF1.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16734,7 +16734,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF0</value>
   </data>
   <data name="&gt;&gt;radBandVHF0.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF0.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16755,7 +16755,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelBandVHF</value>
   </data>
   <data name="&gt;&gt;panelBandVHF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelBandVHF.Parent" xml:space="preserve">
     <value>$this</value>
@@ -16788,7 +16788,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbSquelch</value>
   </data>
   <data name="&gt;&gt;ptbSquelch.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbSquelch.Parent" xml:space="preserve">
     <value>$this</value>
@@ -16827,7 +16827,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbFMMic</value>
   </data>
   <data name="&gt;&gt;ptbFMMic.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbFMMic.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16863,7 +16863,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblMicValFM</value>
   </data>
   <data name="&gt;&gt;lblMicValFM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblMicValFM.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16896,7 +16896,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS7</value>
   </data>
   <data name="&gt;&gt;labelTS7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS7.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16932,7 +16932,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFMOffset</value>
   </data>
   <data name="&gt;&gt;lblFMOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFMOffset.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16968,7 +16968,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFMDeviation</value>
   </data>
   <data name="&gt;&gt;lblFMDeviation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFMDeviation.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16992,7 +16992,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>comboFMMemory</value>
   </data>
   <data name="&gt;&gt;comboFMMemory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboFMMemory.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -17028,7 +17028,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFMMic</value>
   </data>
   <data name="&gt;&gt;lblFMMic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFMMic.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -17049,7 +17049,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelModeSpecificFM</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificFM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificFM.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17091,7 +17091,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnBandHF1</value>
   </data>
   <data name="&gt;&gt;btnBandHF1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnBandHF1.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -17112,7 +17112,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelBandGEN</value>
   </data>
   <data name="&gt;&gt;panelBandGEN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelBandGEN.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17154,7 +17154,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRXMeter</value>
   </data>
   <data name="&gt;&gt;lblRXMeter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRXMeter.Parent" xml:space="preserve">
     <value>panelMeterLabels</value>
@@ -17178,7 +17178,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelMeterLabels</value>
   </data>
   <data name="&gt;&gt;panelMeterLabels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelMeterLabels.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17199,7 +17199,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpMultimeterMenus</value>
   </data>
   <data name="&gt;&gt;grpMultimeterMenus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpMultimeterMenus.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17235,7 +17235,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>tbAndromedaEncoderSlider</value>
   </data>
   <data name="&gt;&gt;tbAndromedaEncoderSlider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBarTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TrackBarTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;tbAndromedaEncoderSlider.Parent" xml:space="preserve">
     <value>panelAndromedaMisc</value>
@@ -17271,7 +17271,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAndromedaEncoderSlider</value>
   </data>
   <data name="&gt;&gt;lblAndromedaEncoderSlider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAndromedaEncoderSlider.Parent" xml:space="preserve">
     <value>panelAndromedaMisc</value>
@@ -17307,7 +17307,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblATUTuneLabel</value>
   </data>
   <data name="&gt;&gt;lblATUTuneLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblATUTuneLabel.Parent" xml:space="preserve">
     <value>panelAndromedaMisc</value>
@@ -17328,7 +17328,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelAndromedaMisc</value>
   </data>
   <data name="&gt;&gt;panelAndromedaMisc.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelAndromedaMisc.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17352,7 +17352,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>nudPwrTemp</value>
   </data>
   <data name="&gt;&gt;nudPwrTemp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;nudPwrTemp.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17376,7 +17376,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>nudPwrTemp2</value>
   </data>
   <data name="&gt;&gt;nudPwrTemp2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.9.0.8, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;nudPwrTemp2.Parent" xml:space="preserve">
     <value>$this</value>

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -51,6 +51,7 @@ namespace Thetis
     using System.Security.Cryptography;
     using System.Xml;
     using System.Xml.Serialization;
+    using System.Diagnostics.Eventing.Reader;
 
     public partial class Setup : Form
     {
@@ -2390,6 +2391,9 @@ namespace Thetis
 
             //
             chkForceATTwhenPSAoff_CheckedChanged(this, e); //MW0LGE [2.9.0.7]
+
+            //options2 tab
+            chkQuickSplit_CheckedChanged(this, e);
         }
 
         public string[] GetTXProfileStrings()
@@ -6957,6 +6961,11 @@ namespace Thetis
         {
             get { return tcGeneral; }
             set { tcGeneral = value; }
+        }
+        public TabControl TabOptions
+        {
+            get { return tcOptions; }
+            set { tcOptions = value; }
         }
         public TabControl TabDisplay
         {
@@ -21553,7 +21562,8 @@ namespace Thetis
             DISPGEN_Tab,
             DISPRX1_Tab,
             DISPRX2_Tab,
-            SpotTCI
+            SpotTCI,
+            OPTIONS2_Tab
         }
         public void ShowSetupTab(SetupTab eTab)
         {
@@ -21636,6 +21646,11 @@ namespace Thetis
                 case SetupTab.SpotTCI:
                     TabSetup.SelectedIndex = 8; // cat
                     TabCAT.SelectedIndex = 2; // user
+                    break;
+                case SetupTab.OPTIONS2_Tab:
+                    TabSetup.SelectedIndex = 0; // general
+                    TabGeneral.SelectedIndex = 2; // options
+                    TabOptions.SelectedIndex = 1; // options2
                     break;
             }
         }
@@ -26971,6 +26986,50 @@ namespace Thetis
         private void btnClearTCISpots_Click(object sender, EventArgs e)
         {
             SpotManager2.ClearAllSpots();
+        }
+
+        public bool QuickSplitEnabled
+        {
+            get { return chkQuickSplit.Checked; }
+            set { chkQuickSplit.Checked = value; }
+        }
+        public int QuickSplitShiftHz
+        {
+            get { return (int)nudQuickSplitShift.Value; }
+            set { nudQuickSplitShift.Value = (decimal)value; }
+        }
+        public bool QuickSplitZoom
+        {
+            get { return chkQuickSplitZoom.Checked; }
+        }
+        public bool QuickSplitMultiRX
+        {
+            get { return chkQuickSplitMultiRX.Checked; }
+        }
+        public bool QuickSplitFL
+        {
+            get { return chkQuickSplitFL.Checked; }
+        }
+        public bool QuickSplitSwapVFOWheels
+        {
+            get { return chkQuickSplitSwapVFOWheels.Checked; }
+        }
+        private void chkQuickSplit_CheckedChanged(object sender, EventArgs e)
+        {
+            if (initializing) return;
+
+            grpQuickSplit.Enabled = chkQuickSplit.Checked;
+            console.SetQuickSplit();
+        }
+
+        private void btnQuickSplitDown5_Click(object sender, EventArgs e)
+        {
+            QuickSplitShiftHz = -5000;
+        }
+
+        private void btnQuickSplitUp5_Click(object sender, EventArgs e)
+        {
+            QuickSplitShiftHz = 5000;
         }
     }
 

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -336,6 +336,16 @@
             this.lblOptClickTuneDIGU = new System.Windows.Forms.LabelTS();
             this.udOptClickTuneOffsetDIGU = new System.Windows.Forms.NumericUpDownTS();
             this.tpOptions2 = new System.Windows.Forms.TabPage();
+            this.chkQuickSplit = new System.Windows.Forms.CheckBoxTS();
+            this.grpQuickSplit = new System.Windows.Forms.GroupBoxTS();
+            this.btnQuickSplitUp5 = new System.Windows.Forms.ButtonTS();
+            this.btnQuickSplitDown5 = new System.Windows.Forms.ButtonTS();
+            this.chkQuickSplitSwapVFOWheels = new System.Windows.Forms.CheckBoxTS();
+            this.chkQuickSplitFL = new System.Windows.Forms.CheckBoxTS();
+            this.chkQuickSplitMultiRX = new System.Windows.Forms.CheckBoxTS();
+            this.chkQuickSplitZoom = new System.Windows.Forms.CheckBoxTS();
+            this.labelTS182 = new System.Windows.Forms.LabelTS();
+            this.nudQuickSplitShift = new System.Windows.Forms.NumericUpDownTS();
             this.groupBoxTS26 = new System.Windows.Forms.GroupBoxTS();
             this.btnResetNFShift = new System.Windows.Forms.ButtonTS();
             this.labelTS160 = new System.Windows.Forms.LabelTS();
@@ -3551,6 +3561,8 @@
             ((System.ComponentModel.ISupportInitialize)(this.udOptClickTuneOffsetDIGL)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.udOptClickTuneOffsetDIGU)).BeginInit();
             this.tpOptions2.SuspendLayout();
+            this.grpQuickSplit.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudQuickSplitShift)).BeginInit();
             this.groupBoxTS26.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudNFshift)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudNFsensitivity)).BeginInit();
@@ -8860,6 +8872,8 @@
             // tpOptions2
             // 
             this.tpOptions2.BackColor = System.Drawing.SystemColors.Control;
+            this.tpOptions2.Controls.Add(this.chkQuickSplit);
+            this.tpOptions2.Controls.Add(this.grpQuickSplit);
             this.tpOptions2.Controls.Add(this.groupBoxTS26);
             this.tpOptions2.Controls.Add(this.groupBoxTS23);
             this.tpOptions2.Controls.Add(this.groupBoxTS22);
@@ -8870,6 +8884,140 @@
             this.tpOptions2.Size = new System.Drawing.Size(716, 384);
             this.tpOptions2.TabIndex = 1;
             this.tpOptions2.Text = "Options-2";
+            // 
+            // chkQuickSplit
+            // 
+            this.chkQuickSplit.AutoSize = true;
+            this.chkQuickSplit.Image = null;
+            this.chkQuickSplit.Location = new System.Drawing.Point(446, 194);
+            this.chkQuickSplit.Name = "chkQuickSplit";
+            this.chkQuickSplit.Size = new System.Drawing.Size(189, 17);
+            this.chkQuickSplit.TabIndex = 37;
+            this.chkQuickSplit.Text = "Quick Split   (rx on vfoa tx on vfob)";
+            this.chkQuickSplit.UseVisualStyleBackColor = true;
+            this.chkQuickSplit.CheckedChanged += new System.EventHandler(this.chkQuickSplit_CheckedChanged);
+            // 
+            // grpQuickSplit
+            // 
+            this.grpQuickSplit.Controls.Add(this.btnQuickSplitUp5);
+            this.grpQuickSplit.Controls.Add(this.btnQuickSplitDown5);
+            this.grpQuickSplit.Controls.Add(this.chkQuickSplitSwapVFOWheels);
+            this.grpQuickSplit.Controls.Add(this.chkQuickSplitFL);
+            this.grpQuickSplit.Controls.Add(this.chkQuickSplitMultiRX);
+            this.grpQuickSplit.Controls.Add(this.chkQuickSplitZoom);
+            this.grpQuickSplit.Controls.Add(this.labelTS182);
+            this.grpQuickSplit.Controls.Add(this.nudQuickSplitShift);
+            this.grpQuickSplit.Location = new System.Drawing.Point(440, 195);
+            this.grpQuickSplit.Name = "grpQuickSplit";
+            this.grpQuickSplit.Size = new System.Drawing.Size(255, 156);
+            this.grpQuickSplit.TabIndex = 36;
+            this.grpQuickSplit.TabStop = false;
+            // 
+            // btnQuickSplitUp5
+            // 
+            this.btnQuickSplitUp5.Image = null;
+            this.btnQuickSplitUp5.Location = new System.Drawing.Point(185, 30);
+            this.btnQuickSplitUp5.Name = "btnQuickSplitUp5";
+            this.btnQuickSplitUp5.Selectable = true;
+            this.btnQuickSplitUp5.Size = new System.Drawing.Size(42, 23);
+            this.btnQuickSplitUp5.TabIndex = 44;
+            this.btnQuickSplitUp5.Text = "+5kHz";
+            this.btnQuickSplitUp5.UseVisualStyleBackColor = true;
+            this.btnQuickSplitUp5.Click += new System.EventHandler(this.btnQuickSplitUp5_Click);
+            // 
+            // btnQuickSplitDown5
+            // 
+            this.btnQuickSplitDown5.Image = null;
+            this.btnQuickSplitDown5.Location = new System.Drawing.Point(138, 30);
+            this.btnQuickSplitDown5.Name = "btnQuickSplitDown5";
+            this.btnQuickSplitDown5.Selectable = true;
+            this.btnQuickSplitDown5.Size = new System.Drawing.Size(42, 23);
+            this.btnQuickSplitDown5.TabIndex = 38;
+            this.btnQuickSplitDown5.Text = "-5kHz";
+            this.btnQuickSplitDown5.UseVisualStyleBackColor = true;
+            this.btnQuickSplitDown5.Click += new System.EventHandler(this.btnQuickSplitDown5_Click);
+            // 
+            // chkQuickSplitSwapVFOWheels
+            // 
+            this.chkQuickSplitSwapVFOWheels.AutoSize = true;
+            this.chkQuickSplitSwapVFOWheels.Image = null;
+            this.chkQuickSplitSwapVFOWheels.Location = new System.Drawing.Point(19, 128);
+            this.chkQuickSplitSwapVFOWheels.Name = "chkQuickSplitSwapVFOWheels";
+            this.chkQuickSplitSwapVFOWheels.Size = new System.Drawing.Size(143, 17);
+            this.chkQuickSplitSwapVFOWheels.TabIndex = 43;
+            this.chkQuickSplitSwapVFOWheels.Text = "Swap VFO-Wheels (midi)";
+            this.chkQuickSplitSwapVFOWheels.UseVisualStyleBackColor = true;
+            // 
+            // chkQuickSplitFL
+            // 
+            this.chkQuickSplitFL.AutoSize = true;
+            this.chkQuickSplitFL.Image = null;
+            this.chkQuickSplitFL.Location = new System.Drawing.Point(19, 105);
+            this.chkQuickSplitFL.Name = "chkQuickSplitFL";
+            this.chkQuickSplitFL.Size = new System.Drawing.Size(143, 17);
+            this.chkQuickSplitFL.TabIndex = 42;
+            this.chkQuickSplitFL.Text = "Enable TX filter lines (FL)";
+            this.chkQuickSplitFL.UseVisualStyleBackColor = true;
+            // 
+            // chkQuickSplitMultiRX
+            // 
+            this.chkQuickSplitMultiRX.AutoSize = true;
+            this.chkQuickSplitMultiRX.Image = null;
+            this.chkQuickSplitMultiRX.Location = new System.Drawing.Point(19, 82);
+            this.chkQuickSplitMultiRX.Name = "chkQuickSplitMultiRX";
+            this.chkQuickSplitMultiRX.Size = new System.Drawing.Size(99, 17);
+            this.chkQuickSplitMultiRX.TabIndex = 41;
+            this.chkQuickSplitMultiRX.Text = "Enable MultiRX";
+            this.chkQuickSplitMultiRX.UseVisualStyleBackColor = true;
+            // 
+            // chkQuickSplitZoom
+            // 
+            this.chkQuickSplitZoom.AutoSize = true;
+            this.chkQuickSplitZoom.Image = null;
+            this.chkQuickSplitZoom.Location = new System.Drawing.Point(19, 59);
+            this.chkQuickSplitZoom.Name = "chkQuickSplitZoom";
+            this.chkQuickSplitZoom.Size = new System.Drawing.Size(65, 17);
+            this.chkQuickSplitZoom.TabIndex = 40;
+            this.chkQuickSplitZoom.Text = "Zoom In";
+            this.chkQuickSplitZoom.UseVisualStyleBackColor = true;
+            // 
+            // labelTS182
+            // 
+            this.labelTS182.AutoSize = true;
+            this.labelTS182.Image = null;
+            this.labelTS182.Location = new System.Drawing.Point(89, 35);
+            this.labelTS182.Name = "labelTS182";
+            this.labelTS182.Size = new System.Drawing.Size(29, 13);
+            this.labelTS182.TabIndex = 39;
+            this.labelTS182.Text = "± Hz";
+            // 
+            // nudQuickSplitShift
+            // 
+            this.nudQuickSplitShift.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nudQuickSplitShift.Location = new System.Drawing.Point(19, 33);
+            this.nudQuickSplitShift.Maximum = new decimal(new int[] {
+            15000,
+            0,
+            0,
+            0});
+            this.nudQuickSplitShift.Minimum = new decimal(new int[] {
+            15000,
+            0,
+            0,
+            -2147483648});
+            this.nudQuickSplitShift.Name = "nudQuickSplitShift";
+            this.nudQuickSplitShift.Size = new System.Drawing.Size(64, 20);
+            this.nudQuickSplitShift.TabIndex = 38;
+            this.nudQuickSplitShift.TinyStep = false;
+            this.nudQuickSplitShift.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
             // 
             // groupBoxTS26
             // 
@@ -55121,6 +55269,10 @@
             ((System.ComponentModel.ISupportInitialize)(this.udOptClickTuneOffsetDIGL)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.udOptClickTuneOffsetDIGU)).EndInit();
             this.tpOptions2.ResumeLayout(false);
+            this.tpOptions2.PerformLayout();
+            this.grpQuickSplit.ResumeLayout(false);
+            this.grpQuickSplit.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudQuickSplitShift)).EndInit();
             this.groupBoxTS26.ResumeLayout(false);
             this.groupBoxTS26.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudNFshift)).EndInit();
@@ -59549,5 +59701,15 @@
         private LabelTS lblTXProfileWarning;
         private Timer tmrCheckProfile;
         private ButtonTS btnClearTCISpots;
+        private GroupBoxTS grpQuickSplit;
+        private CheckBoxTS chkQuickSplit;
+        private NumericUpDownTS nudQuickSplitShift;
+        private LabelTS labelTS182;
+        private CheckBoxTS chkQuickSplitSwapVFOWheels;
+        private CheckBoxTS chkQuickSplitFL;
+        private CheckBoxTS chkQuickSplitMultiRX;
+        private CheckBoxTS chkQuickSplitZoom;
+        private ButtonTS btnQuickSplitUp5;
+        private ButtonTS btnQuickSplitDown5;
     }
 }

--- a/Project Files/Source/Console/titlebar.cs
+++ b/Project Files/Source/Console/titlebar.cs
@@ -34,7 +34,7 @@ namespace Thetis
 {
     class TitleBar
     {
-        public const string BUILD_NAME = "wip_lge_8";
+        public const string BUILD_NAME = "wip_lge_10";
         public const string BUILD_DATE = "(10/02/23)<FW>"; //MW0LGE_21g <FW> gets replaced in BasicTitle (console.cs) with firmware version
 
         public static string GetString()

--- a/Project Files/Source/Midi2Cat/Midi2Cat.Data/CatCmdDb.cs
+++ b/Project Files/Source/Midi2Cat/Midi2Cat.Data/CatCmdDb.cs
@@ -497,6 +497,10 @@ namespace Midi2Cat.Data
         RX2AutoAGC = 302,
         [CatCommandAttribute("Swap VFO Wheels", ControlType.Button, true)] // MW0LGE [2.9.0.7]
         SwapVFOWheels = 303,
+        [CatCommandAttribute("Quick Split On Off", ControlType.Button, true)]
+        QuickSplitOnOff = 304,
+        [CatCommandAttribute("Quick Split + VFO Split On Off", ControlType.Button, true)]
+        QuickSplitOnOffandSplitOnOff = 305,
         [CatCommandAttribute("Toggle Wheel to VFOA/VFOB ", ControlType.Button)]  //-W2PA Added a toggle between A/B for main wheel 
         ToggleVFOWheel = 700
     }


### PR DESCRIPTION
Quick Split option when using rx1 only. Added ZZZN and ZZZO, as well as midi support. Config in options2 tab, or right click split button. Shift left click split button to enable QPLT when only rx1 enabled.