### PR TITLE
final push for v2.10.2 + fix for colours not being set on fresh db

### DIFF
--- a/Project Files/Source/Console/AssemblyInfo.cs
+++ b/Project Files/Source/Console/AssemblyInfo.cs
@@ -54,7 +54,7 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("2.10.1.0")]
+[assembly: AssemblyVersion("2.10.2.0")]
 
 //
 // In order to sign your assembly you must specify a key to use. Refer to the 

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -40412,7 +40412,6 @@ namespace Thetis
                     chkANF.Enabled = true;
                     chkANF_CheckedChanged(this, EventArgs.Empty);
 
-
                     if (!RX1IsIn60mChannel())
                     {
                         switch (new_mode)

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -2274,6 +2274,17 @@ namespace Thetis
             chkNoiseFloorShowDBM_CheckedChanged(this, e);
             udNoiseFloorLineWidth_ValueChanged(this, e);
 
+            //[2.10.1.0]MW0LGE mainly colours
+            clrbtnOutOfBand_Changed(this, e);
+            chkVFOSmallLSD_CheckedChanged(this, e);
+            clrbtnVFOSmallColor_Changed(this, e);
+            clrbtnInfoButtonsColor_Changed(this, e);
+            clrbtnPeakBackground_Changed(this, e);
+            clrbtnMeterBackground_Changed(this, e);
+            clrbtnBandBackground_Changed(this, e);
+            clrbtnVFOBackground_Changed(this, e);
+            //
+
             // RX2 tab
             chkRX2AutoMuteTX_CheckedChanged(this, e);
             udMoxDelay_ValueChanged(this, e);

--- a/Project Files/Source/Console/titlebar.cs
+++ b/Project Files/Source/Console/titlebar.cs
@@ -34,8 +34,8 @@ namespace Thetis
 {
     class TitleBar
     {
-        public const string BUILD_NAME = "wip_lge_11";
-        public const string BUILD_DATE = "(10/02/23)<FW>"; //MW0LGE_21g <FW> gets replaced in BasicTitle (console.cs) with firmware version
+        public const string BUILD_NAME = "";
+        public const string BUILD_DATE = "(10/04/23)<FW>"; //MW0LGE_21g <FW> gets replaced in BasicTitle (console.cs) with firmware version
 
         public static string GetString()
         {


### PR DESCRIPTION
1) colours now set on some controls when a fresh db is used. There would always be some grey boxes in the vfos on a fresh without a db

2) assembly version changed to v2.10.2 in readiness for pre-release