### PR TITLE
FIX Highlight control + Smooth meter item fade

### DIFF
--- a/Project Files/Source/Console/MeterManager.cs
+++ b/Project Files/Source/Console/MeterManager.cs
@@ -2042,6 +2042,7 @@ namespace Thetis
             private float _maxPower;
             private string _readingName;
 
+            private int _fadeValue;
             public clsMeterItem()
             {
                 // constructor
@@ -2074,6 +2075,12 @@ namespace Thetis
                 _maxPower = CurrentPowerRating;//100f;
                 _percCache = new Dictionary<float, clsPercCache>();
                 _updateStopwatch = new Stopwatch();
+                _fadeValue = 255;
+            }
+            public int FadeValue //[2.10.1.0] MW0LGE used for on rx/tx fading
+            {
+                get { return _fadeValue; }
+                set { _fadeValue = value; }
             }
             public void AddPerc(clsPercCache pc)
             {
@@ -8962,6 +8969,31 @@ namespace Thetis
 
                 return size;
             }
+            // [2.10.1.0] MW0LGE
+            private int fade(clsMeterItem mi, clsMeter m)
+            {
+                if (!mi.FadeOnTx && m.MOX && mi.FadeValue == 255) return 255;
+                if (!mi.FadeOnRx && !m.MOX && mi.FadeValue == 255) return 255;
+
+                int updateInterval = m.QuickestUpdateInterval(m.MOX);
+                // fade to take half a second
+                int steps_needed = (int)Math.Ceiling(500 / (float)updateInterval);
+                int stepSize = (int)Math.Ceiling(207 / (float)steps_needed); // 255-48 = 207
+
+                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx))
+                {
+                    mi.FadeValue -= stepSize;
+                    if (mi.FadeValue < 48) mi.FadeValue = 48;
+                }
+                else
+                {
+                    mi.FadeValue += stepSize;
+                    if (mi.FadeValue > 255) mi.FadeValue = 255;
+                }
+
+                return mi.FadeValue;
+            }
+            //
             private void renderNeedleScale(SharpDX.RectangleF rect, clsMeterItem mi, clsMeter m)
             {
                 clsNeedleScalePwrItem scale = (clsNeedleScalePwrItem)mi;
@@ -8973,8 +9005,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 SharpDX.RectangleF mirect = new SharpDX.RectangleF(x, y, w, h);
                 //_renderTarget.DrawRectangle(mirect, getDXBrushForColour(System.Drawing.Color.CornflowerBlue));
@@ -9188,8 +9219,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 SharpDX.RectangleF mirect = new SharpDX.RectangleF(x, y, w, h);
                 //_renderTarget.DrawRectangle(mirect, getDXBrushForColour(System.Drawing.Color.CornflowerBlue));
@@ -9740,8 +9770,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 //SharpDX.RectangleF mirect = new SharpDX.RectangleF(x, y, w, h);
                 //_renderTarget.DrawRectangle(mirect, getDXBrushForColour(System.Drawing.Color.Green));
@@ -9867,8 +9896,7 @@ namespace Thetis
             //    float w = rect.Width * (mi.Size.Width / m.XRatio);
             //    float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-            //    int nFade = 255;
-            //    if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+            //    int nFade = fade(mi, m);
 
             //    SharpDX.RectangleF mirect = new SharpDX.RectangleF(x, y, w, h);
             //    _renderTarget.DrawRectangle(mirect, getDXBrushForColour(System.Drawing.Color.Green));
@@ -9928,8 +9956,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 string sText;
                 switch (txt.Text.ToLower())
@@ -9974,8 +10001,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 PointF min, max;
                 float percX, percY;
@@ -10012,8 +10038,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 //SharpDX.RectangleF mirect = new SharpDX.RectangleF(x, y, w, h);
                 //_renderTarget.DrawRectangle(mirect, getDXBrushForColour(System.Drawing.Color.Red));
@@ -10381,8 +10406,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 SharpDX.RectangleF rectSC = new SharpDX.RectangleF(x, y, w, h);
                 _renderTarget.FillRectangle(rectSC, getDXBrushForColour(sc.Colour, nFade < sc.Colour.A ? nFade : sc.Colour.A));
@@ -10423,8 +10447,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 int nVfoAFade = nFade;
                 int nVfoBFade = nFade;
@@ -10563,8 +10586,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 DateTime now = DateTime.Now;
                 DateTime UTCnow = DateTime.UtcNow;
@@ -10630,8 +10652,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;              
+                int nFade = fade(mi, m);
 
                 float fontSizeEmScaled;
                 SizeF szTextSize;
@@ -10698,8 +10719,7 @@ namespace Thetis
             //        float w = rect.Width * (mi.Size.Width / m.XRatio);
             //        float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-            //        int nFade = 255;
-            //        if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+            //        int nFade = fade(mi, m);
 
             //        float top = Display.SpectrumGridMax; //dbm
             //        float bottom = Display.SpectrumGridMin; //-150; //dbm
@@ -10767,8 +10787,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 string sImage = img.ImageName;
 
@@ -10839,8 +10858,7 @@ namespace Thetis
                 float w = rect.Width * (mi.Size.Width / m.XRatio);
                 float h = rect.Height * (mi.Size.Height / m.YRatio);
 
-                int nFade = 255;
-                if ((m.MOX && mi.FadeOnTx) || (!m.MOX && mi.FadeOnRx)) nFade = 48;
+                int nFade = fade(mi, m);
 
                 SharpDX.RectangleF nirect = new SharpDX.RectangleF(x, y, w, h);
                 //_renderTarget.DrawRectangle(nirect, getDXBrushForColour(System.Drawing.Color.Red));

--- a/Project Files/Source/Console/common.cs
+++ b/Project Files/Source/Console/common.cs
@@ -52,6 +52,14 @@ namespace Thetis
 			return source?.IndexOf(toCheck, comp) >= 0;
 		}
 	}
+    public static class ControlExtentions
+    {
+        public static string GetFullName(this Control control)
+        {
+            if (control.Parent == null) return control.Name;
+            return control.Parent.GetFullName() + "." + control.Name;
+        }
+    }
     //public static class Extensions
     //{
     //    private const double Epsilon = 1e-10;
@@ -69,83 +77,88 @@ namespace Thetis
 
 		public static MessageBoxOptions MB_TOPMOST = (MessageBoxOptions)0x00040000L; //MW0LGE_21g TOPMOST for MessageBox
 
-		#region HiglightControls
-		private static Dictionary<string, Color> m_backgroundColours = new Dictionary<string, Color>();
+        #region HiglightControls
+        private static Dictionary<string, Color> m_backgroundColours = new Dictionary<string, Color>();
 		private static Dictionary<string, Color> m_foregoundColours = new Dictionary<string, Color>();
 		private static Dictionary<string, FlatStyle> m_flatStyle = new Dictionary<string, FlatStyle>();
 		private static Dictionary<string, Image> m_backImage = new Dictionary<string, Image>();
 		public static void HightlightControl(Control c, bool bHighlight)
 		{
-			if (!m_backgroundColours.ContainsKey(c.Name))
+			string sKey = c.GetFullName(); //[2.10.1.0] added because control with same name can be in different forms/containers
+
+			if (!m_backgroundColours.ContainsKey(sKey))
 			{
-				m_backgroundColours.Add(c.Name, c.BackColor);
+				m_backgroundColours.Add(sKey, c.BackColor);
 			}
-			if (!m_foregoundColours.ContainsKey(c.Name))
+			if (!m_foregoundColours.ContainsKey(sKey))
 			{
-				m_foregoundColours.Add(c.Name, c.ForeColor);
+				m_foregoundColours.Add(sKey, c.ForeColor);
 			}
-			if (!m_backImage.ContainsKey(c.Name))
+			if (!m_backImage.ContainsKey(sKey))
 			{
-				m_backImage.Add(c.Name, c.BackgroundImage);
+				m_backImage.Add(sKey, c.BackgroundImage);
 			}
 
 			if (c.GetType() == typeof(NumericUpDownTS))
 			{
-				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[c.Name];
-			}
+				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[sKey];
+                c.ForeColor = bHighlight ? Color.Black : m_foregoundColours[sKey];
+            }
 			else if (c.GetType() == typeof(CheckBoxTS))
 			{
 				CheckBoxTS cb = c as CheckBoxTS;
-				if (!m_flatStyle.ContainsKey(cb.Name)) m_flatStyle.Add(cb.Name, cb.FlatStyle);
-				cb.FlatStyle = bHighlight ? FlatStyle.Flat : m_flatStyle[cb.Name];
-				cb.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[cb.Name];
-				cb.ForeColor = bHighlight ? Color.Red : m_foregoundColours[cb.Name];
-				cb.BackgroundImage = bHighlight ? null : m_backImage[cb.Name];
+				if (!m_flatStyle.ContainsKey(sKey)) m_flatStyle.Add(sKey, cb.FlatStyle);
+				cb.FlatStyle = bHighlight ? FlatStyle.Flat : m_flatStyle[sKey];
+				cb.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[sKey];
+				cb.ForeColor = bHighlight ? Color.Red : m_foregoundColours[sKey];
+				cb.BackgroundImage = bHighlight ? null : m_backImage[sKey];
 			}
 			else if (c.GetType() == typeof(TrackBarTS))
 			{
-				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[c.Name];
-				c.ForeColor = bHighlight ? Color.Yellow : m_foregoundColours[c.Name];
-				c.BackgroundImage = bHighlight ? null : m_backImage[c.Name];
+				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[sKey];
+				c.ForeColor = bHighlight ? Color.Yellow : m_foregoundColours[sKey];
+				c.BackgroundImage = bHighlight ? null : m_backImage[sKey];
 			}
 			else if (c.GetType() == typeof(PrettyTrackBar))
 			{
-				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[c.Name];
-				c.ForeColor = bHighlight ? Color.Yellow : m_foregoundColours[c.Name];
-				c.BackgroundImage = bHighlight ? null : m_backImage[c.Name];
+				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[sKey];
+				c.ForeColor = bHighlight ? Color.Yellow : m_foregoundColours[sKey];
+				c.BackgroundImage = bHighlight ? null : m_backImage[sKey];
 			}
 			else if (c.GetType() == typeof(ComboBoxTS))
 			{
 				ComboBoxTS cb = c as ComboBoxTS;
-				if (!m_flatStyle.ContainsKey(cb.Name)) m_flatStyle.Add(cb.Name, cb.FlatStyle);
-				cb.FlatStyle = bHighlight ? FlatStyle.Flat : m_flatStyle[cb.Name];
-				cb.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[cb.Name];
-				cb.ForeColor = bHighlight ? Color.Red : m_foregoundColours[cb.Name];
+				if (!m_flatStyle.ContainsKey(sKey)) m_flatStyle.Add(sKey, cb.FlatStyle);
+				cb.FlatStyle = bHighlight ? FlatStyle.Flat : m_flatStyle[sKey];
+				cb.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[sKey];
+				cb.ForeColor = bHighlight ? Color.Red : m_foregoundColours[sKey];
 			}
 			else if (c.GetType() == typeof(RadioButtonTS))
 			{
 				RadioButtonTS cb = c as RadioButtonTS;
-				if (!m_flatStyle.ContainsKey(cb.Name)) m_flatStyle.Add(cb.Name, cb.FlatStyle);
-				cb.FlatStyle = bHighlight ? FlatStyle.Flat : m_flatStyle[cb.Name];
-				cb.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[cb.Name];
-				cb.ForeColor = bHighlight ? Color.Red : m_foregoundColours[cb.Name];
-				cb.BackgroundImage = bHighlight ? null : m_backImage[cb.Name];
+				if (!m_flatStyle.ContainsKey(sKey)) m_flatStyle.Add(sKey, cb.FlatStyle);
+				cb.FlatStyle = bHighlight ? FlatStyle.Flat : m_flatStyle[sKey];
+				cb.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[sKey];
+				cb.ForeColor = bHighlight ? Color.Red : m_foregoundColours[sKey];
+				cb.BackgroundImage = bHighlight ? null : m_backImage[sKey];
 			}
 			else if (c.GetType() == typeof(TextBoxTS))
 			{
-				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[c.Name];
-			}
+				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[sKey];
+                c.ForeColor = bHighlight ? Color.Black : m_foregoundColours[sKey];
+            }
 			else if (c.GetType() == typeof(LabelTS))
 			{
-				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[c.Name];
-			}
+				c.BackColor = bHighlight ? Color.Yellow : m_backgroundColours[sKey];
+                c.ForeColor = bHighlight ? Color.Black : m_foregoundColours[sKey];
+            }
 
 			if (!bHighlight)
 			{
-				if (!m_backgroundColours.ContainsKey(c.Name)) m_backgroundColours.Remove(c.Name);
-				if (!m_foregoundColours.ContainsKey(c.Name)) m_foregoundColours.Remove(c.Name);
-				if (!m_flatStyle.ContainsKey(c.Name)) m_flatStyle.Remove(c.Name);
-				if (!m_backImage.ContainsKey(c.Name)) m_backImage.Remove(c.Name);
+				if (!m_backgroundColours.ContainsKey(sKey)) m_backgroundColours.Remove(sKey);
+				if (!m_foregoundColours.ContainsKey(sKey)) m_foregoundColours.Remove(sKey);
+				if (!m_flatStyle.ContainsKey(sKey)) m_flatStyle.Remove(sKey);
+				if (!m_backImage.ContainsKey(sKey)) m_backImage.Remove(sKey);
 			}
 
 			c.Invalidate();

--- a/Project Files/Source/Console/titlebar.cs
+++ b/Project Files/Source/Console/titlebar.cs
@@ -34,7 +34,7 @@ namespace Thetis
 {
     class TitleBar
     {
-        public const string BUILD_NAME = "pre-release";
+        public const string BUILD_NAME = "pre-release2";
         public const string BUILD_DATE = "(10/04/23)<FW>"; //MW0LGE_21g <FW> gets replaced in BasicTitle (console.cs) with firmware version
 
         public static string GetString()


### PR DESCRIPTION
1) Issue fixed where control name was the same in two forms but different colours etc. Now uniquely keyed to fix this issue. 

2) Added smooth fade over 500ms for meter items that have fade TX/RX enabled