### PR TITLE
Legacy meter enable/disable, VFOtx toggle on spacebar, some other fixes

### DIFF
--- a/Project Files/Source/Console/console.Designer.cs
+++ b/Project Files/Source/Console/console.Designer.cs
@@ -719,6 +719,7 @@
             this.comboAMTXProfile = new System.Windows.Forms.ComboBoxTS();
             this.btnDisplayZTB = new System.Windows.Forms.ButtonTS();
             this.ptbTune = new Thetis.PrettyTrackBar();
+            this.lblPAProfile = new System.Windows.Forms.LabelTS();
             this.picSquelch = new System.Windows.Forms.PictureBox();
             this.timer_clock = new System.Windows.Forms.Timer(this.components);
             this.contextMenuStripFilterRX1 = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -905,7 +906,6 @@
             this.toolStripStatusLabel_Date = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusLabel_LocalTime = new System.Windows.Forms.ToolStripStatusLabel();
             this.tmrAutoAGC = new System.Windows.Forms.Timer(this.components);
-            this.lblPAProfile = new System.Windows.Forms.LabelTS();
             this.nudPwrTemp2 = new System.Windows.Forms.NumericUpDownTS();
             this.nudPwrTemp = new System.Windows.Forms.NumericUpDownTS();
             this.grpMultimeter = new System.Windows.Forms.GroupBoxTS();
@@ -3939,6 +3939,15 @@
             this.ptbTune.Scroll += new Thetis.PrettyTrackBar.ScrollHandler(this.ptbTune_Scroll);
             this.ptbTune.MouseUp += new System.Windows.Forms.MouseEventHandler(this.ptbTune_MouseUp);
             // 
+            // lblPAProfile
+            // 
+            this.lblPAProfile.BackColor = System.Drawing.Color.Transparent;
+            resources.ApplyResources(this.lblPAProfile, "lblPAProfile");
+            this.lblPAProfile.ForeColor = System.Drawing.Color.White;
+            this.lblPAProfile.Name = "lblPAProfile";
+            this.toolTip1.SetToolTip(this.lblPAProfile, resources.GetString("lblPAProfile.ToolTip"));
+            this.lblPAProfile.MouseDown += new System.Windows.Forms.MouseEventHandler(this.lblPAProfile_MouseDown);
+            // 
             // picSquelch
             // 
             this.picSquelch.BackColor = System.Drawing.SystemColors.ControlText;
@@ -5278,15 +5287,6 @@
             this.tmrAutoAGC.Enabled = true;
             this.tmrAutoAGC.Interval = 500;
             this.tmrAutoAGC.Tick += new System.EventHandler(this.tmrAutoAGC_Tick);
-            // 
-            // lblPAProfile
-            // 
-            this.lblPAProfile.BackColor = System.Drawing.Color.Transparent;
-            resources.ApplyResources(this.lblPAProfile, "lblPAProfile");
-            this.lblPAProfile.ForeColor = System.Drawing.Color.White;
-            this.lblPAProfile.Name = "lblPAProfile";
-            this.toolTip1.SetToolTip(this.lblPAProfile, resources.GetString("lblPAProfile.ToolTip"));
-            this.lblPAProfile.MouseDown += new System.Windows.Forms.MouseEventHandler(this.lblPAProfile_MouseDown);
             // 
             // nudPwrTemp2
             // 
@@ -7468,6 +7468,7 @@
             this.KeyPreview = true;
             this.MainMenuStrip = this.menuStrip1;
             this.Name = "Console";
+            this.Opacity = 0D;
             this.Activated += new System.EventHandler(this.Console_Activated);
             this.Closing += new System.ComponentModel.CancelEventHandler(this.Console_Closing);
             this.Deactivate += new System.EventHandler(this.Console_Deactivate);

--- a/Project Files/Source/Console/console.resx
+++ b/Project Files/Source/Console/console.resx
@@ -157,7 +157,7 @@
     <value>ptbFilterShift</value>
   </data>
   <data name="&gt;&gt;ptbFilterShift.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbFilterShift.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -193,7 +193,7 @@
     <value>ptbFilterWidth</value>
   </data>
   <data name="&gt;&gt;ptbFilterWidth.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbFilterWidth.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -232,7 +232,7 @@
     <value>btnFilterShiftReset</value>
   </data>
   <data name="&gt;&gt;btnFilterShiftReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnFilterShiftReset.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -265,7 +265,7 @@
     <value>udFilterHigh</value>
   </data>
   <data name="&gt;&gt;udFilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udFilterHigh.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -298,7 +298,7 @@
     <value>udFilterLow</value>
   </data>
   <data name="&gt;&gt;udFilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udFilterLow.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -334,7 +334,7 @@
     <value>ptbRX2RF</value>
   </data>
   <data name="&gt;&gt;ptbRX2RF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2RF.Parent" xml:space="preserve">
     <value>panelRX2RF</value>
@@ -370,7 +370,7 @@
     <value>lblRX2RF</value>
   </data>
   <data name="&gt;&gt;lblRX2RF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2RF.Parent" xml:space="preserve">
     <value>panelRX2RF</value>
@@ -418,7 +418,7 @@
     <value>chkFullDuplex</value>
   </data>
   <data name="&gt;&gt;chkFullDuplex.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFullDuplex.Parent" xml:space="preserve">
     <value>$this</value>
@@ -457,7 +457,7 @@
     <value>chkRX2Squelch</value>
   </data>
   <data name="&gt;&gt;chkRX2Squelch.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2Squelch.Parent" xml:space="preserve">
     <value>$this</value>
@@ -502,7 +502,7 @@
     <value>chkRX2Mute</value>
   </data>
   <data name="&gt;&gt;chkRX2Mute.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2Mute.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -547,7 +547,7 @@
     <value>chkRX2NB2</value>
   </data>
   <data name="&gt;&gt;chkRX2NB2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2NB2.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -592,7 +592,7 @@
     <value>chkRX2NR</value>
   </data>
   <data name="&gt;&gt;chkRX2NR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2NR.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -637,7 +637,7 @@
     <value>chkRX2NB</value>
   </data>
   <data name="&gt;&gt;chkRX2NB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2NB.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -673,7 +673,7 @@
     <value>lblRX2AGC</value>
   </data>
   <data name="&gt;&gt;lblRX2AGC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2AGC.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -718,7 +718,7 @@
     <value>chkRX2ANF</value>
   </data>
   <data name="&gt;&gt;chkRX2ANF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2ANF.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -745,7 +745,7 @@
     <value>comboRX2AGC</value>
   </data>
   <data name="&gt;&gt;comboRX2AGC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2AGC.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -790,7 +790,7 @@
     <value>chkRX2BIN</value>
   </data>
   <data name="&gt;&gt;chkRX2BIN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2BIN.Parent" xml:space="preserve">
     <value>panelRX2DSP</value>
@@ -835,7 +835,7 @@
     <value>chkExternalPA</value>
   </data>
   <data name="&gt;&gt;chkExternalPA.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkExternalPA.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -880,7 +880,7 @@
     <value>ckQuickPlay</value>
   </data>
   <data name="&gt;&gt;ckQuickPlay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ckQuickPlay.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -925,7 +925,7 @@
     <value>chkMON</value>
   </data>
   <data name="&gt;&gt;chkMON.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkMON.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -967,7 +967,7 @@
     <value>ckQuickRec</value>
   </data>
   <data name="&gt;&gt;ckQuickRec.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ckQuickRec.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1012,7 +1012,7 @@
     <value>chkRX2SR</value>
   </data>
   <data name="&gt;&gt;chkRX2SR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2SR.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1060,7 +1060,7 @@
     <value>chkMOX</value>
   </data>
   <data name="&gt;&gt;chkMOX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkMOX.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1108,7 +1108,7 @@
     <value>chkTUN</value>
   </data>
   <data name="&gt;&gt;chkTUN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkTUN.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1153,7 +1153,7 @@
     <value>chk2TONE</value>
   </data>
   <data name="&gt;&gt;chk2TONE.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chk2TONE.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1198,7 +1198,7 @@
     <value>chkFWCATUBypass</value>
   </data>
   <data name="&gt;&gt;chkFWCATUBypass.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFWCATUBypass.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1240,7 +1240,7 @@
     <value>comboTuneMode</value>
   </data>
   <data name="&gt;&gt;comboTuneMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboTuneMode.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -1285,7 +1285,7 @@
     <value>chkX2TR</value>
   </data>
   <data name="&gt;&gt;chkX2TR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkX2TR.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -1330,7 +1330,7 @@
     <value>chkFWCATU</value>
   </data>
   <data name="&gt;&gt;chkFWCATU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFWCATU.Parent" xml:space="preserve">
     <value>panelDisplay2</value>
@@ -1399,7 +1399,7 @@
     <value>comboRX2Band</value>
   </data>
   <data name="&gt;&gt;comboRX2Band.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2Band.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -1444,7 +1444,7 @@
     <value>chkRX2Preamp</value>
   </data>
   <data name="&gt;&gt;chkRX2Preamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2Preamp.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -1483,7 +1483,7 @@
     <value>chkPower</value>
   </data>
   <data name="&gt;&gt;chkPower.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkPower.Parent" xml:space="preserve">
     <value>panelPower</value>
@@ -1519,7 +1519,7 @@
     <value>ptbCWSpeed</value>
   </data>
   <data name="&gt;&gt;ptbCWSpeed.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCWSpeed.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -1543,7 +1543,7 @@
     <value>udCWPitch</value>
   </data>
   <data name="&gt;&gt;udCWPitch.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udCWPitch.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -1570,7 +1570,7 @@
     <value>udCWBreakInDelay</value>
   </data>
   <data name="&gt;&gt;udCWBreakInDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udCWBreakInDelay.Parent" xml:space="preserve">
     <value>grpSemiBreakIn</value>
@@ -1603,7 +1603,7 @@
     <value>chkShowTXCWFreq</value>
   </data>
   <data name="&gt;&gt;chkShowTXCWFreq.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkShowTXCWFreq.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -1639,7 +1639,7 @@
     <value>chkCWIambic</value>
   </data>
   <data name="&gt;&gt;chkCWIambic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCWIambic.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -1666,7 +1666,7 @@
     <value>udRX2FilterHigh</value>
   </data>
   <data name="&gt;&gt;udRX2FilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRX2FilterHigh.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -1693,7 +1693,7 @@
     <value>udRX2FilterLow</value>
   </data>
   <data name="&gt;&gt;udRX2FilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRX2FilterLow.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -1738,7 +1738,7 @@
     <value>radRX2ModeAM</value>
   </data>
   <data name="&gt;&gt;radRX2ModeAM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeAM.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1783,7 +1783,7 @@
     <value>radRX2ModeLSB</value>
   </data>
   <data name="&gt;&gt;radRX2ModeLSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeLSB.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1828,7 +1828,7 @@
     <value>radRX2ModeSAM</value>
   </data>
   <data name="&gt;&gt;radRX2ModeSAM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeSAM.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1873,7 +1873,7 @@
     <value>radRX2ModeCWL</value>
   </data>
   <data name="&gt;&gt;radRX2ModeCWL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeCWL.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1918,7 +1918,7 @@
     <value>radRX2ModeDSB</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDSB.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -1963,7 +1963,7 @@
     <value>radRX2ModeUSB</value>
   </data>
   <data name="&gt;&gt;radRX2ModeUSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeUSB.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2008,7 +2008,7 @@
     <value>radRX2ModeCWU</value>
   </data>
   <data name="&gt;&gt;radRX2ModeCWU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeCWU.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2053,7 +2053,7 @@
     <value>radRX2ModeFMN</value>
   </data>
   <data name="&gt;&gt;radRX2ModeFMN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeFMN.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2098,7 +2098,7 @@
     <value>radRX2ModeDIGU</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDIGU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDIGU.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2143,7 +2143,7 @@
     <value>radRX2ModeDRM</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDRM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDRM.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2188,7 +2188,7 @@
     <value>radRX2ModeDIGL</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDIGL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeDIGL.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2233,7 +2233,7 @@
     <value>radRX2ModeSPEC</value>
   </data>
   <data name="&gt;&gt;radRX2ModeSPEC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2ModeSPEC.Parent" xml:space="preserve">
     <value>panelRX2Mode</value>
@@ -2278,7 +2278,7 @@
     <value>chkRX2DisplayPeak</value>
   </data>
   <data name="&gt;&gt;chkRX2DisplayPeak.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2DisplayPeak.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -2317,7 +2317,7 @@
     <value>comboRX2DisplayMode</value>
   </data>
   <data name="&gt;&gt;comboRX2DisplayMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2DisplayMode.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -2362,7 +2362,7 @@
     <value>chkPanSwap</value>
   </data>
   <data name="&gt;&gt;chkPanSwap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkPanSwap.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -2407,7 +2407,7 @@
     <value>chkEnableMultiRX</value>
   </data>
   <data name="&gt;&gt;chkEnableMultiRX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkEnableMultiRX.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -2449,7 +2449,7 @@
     <value>chkDisplayPeak</value>
   </data>
   <data name="&gt;&gt;chkDisplayPeak.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkDisplayPeak.Parent" xml:space="preserve">
     <value>panelDisplay2</value>
@@ -2482,7 +2482,7 @@
     <value>comboDisplayMode</value>
   </data>
   <data name="&gt;&gt;comboDisplayMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboDisplayMode.Parent" xml:space="preserve">
     <value>panelDisplay2</value>
@@ -2524,7 +2524,7 @@
     <value>chkDisplayAVG</value>
   </data>
   <data name="&gt;&gt;chkDisplayAVG.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkDisplayAVG.Parent" xml:space="preserve">
     <value>panelDisplay2</value>
@@ -2569,7 +2569,7 @@
     <value>chkNR</value>
   </data>
   <data name="&gt;&gt;chkNR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkNR.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2617,7 +2617,7 @@
     <value>chkDSPNB2</value>
   </data>
   <data name="&gt;&gt;chkDSPNB2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkDSPNB2.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2662,7 +2662,7 @@
     <value>chkBIN</value>
   </data>
   <data name="&gt;&gt;chkBIN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkBIN.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2707,7 +2707,7 @@
     <value>chkNB</value>
   </data>
   <data name="&gt;&gt;chkNB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkNB.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2752,7 +2752,7 @@
     <value>chkANF</value>
   </data>
   <data name="&gt;&gt;chkANF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkANF.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -2791,7 +2791,7 @@
     <value>btnZeroBeat</value>
   </data>
   <data name="&gt;&gt;btnZeroBeat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnZeroBeat.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2836,7 +2836,7 @@
     <value>chkVFOSplit</value>
   </data>
   <data name="&gt;&gt;chkVFOSplit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOSplit.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2872,7 +2872,7 @@
     <value>btnRITReset</value>
   </data>
   <data name="&gt;&gt;btnRITReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnRITReset.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2908,7 +2908,7 @@
     <value>btnXITReset</value>
   </data>
   <data name="&gt;&gt;btnXITReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnXITReset.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2932,7 +2932,7 @@
     <value>udRIT</value>
   </data>
   <data name="&gt;&gt;udRIT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRIT.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -2971,7 +2971,7 @@
     <value>btnIFtoVFO</value>
   </data>
   <data name="&gt;&gt;btnIFtoVFO.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnIFtoVFO.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3013,7 +3013,7 @@
     <value>chkRIT</value>
   </data>
   <data name="&gt;&gt;chkRIT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRIT.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3052,7 +3052,7 @@
     <value>btnVFOSwap</value>
   </data>
   <data name="&gt;&gt;btnVFOSwap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnVFOSwap.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3094,7 +3094,7 @@
     <value>chkXIT</value>
   </data>
   <data name="&gt;&gt;chkXIT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkXIT.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3133,7 +3133,7 @@
     <value>btnVFOBtoA</value>
   </data>
   <data name="&gt;&gt;btnVFOBtoA.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnVFOBtoA.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3157,7 +3157,7 @@
     <value>udXIT</value>
   </data>
   <data name="&gt;&gt;udXIT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udXIT.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3196,7 +3196,7 @@
     <value>btnVFOAtoB</value>
   </data>
   <data name="&gt;&gt;btnVFOAtoB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnVFOAtoB.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3244,7 +3244,7 @@
     <value>chkRX1Preamp</value>
   </data>
   <data name="&gt;&gt;chkRX1Preamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX1Preamp.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -3271,7 +3271,7 @@
     <value>comboAGC</value>
   </data>
   <data name="&gt;&gt;comboAGC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboAGC.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -3307,7 +3307,7 @@
     <value>lblAGC</value>
   </data>
   <data name="&gt;&gt;lblAGC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAGC.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -3334,7 +3334,7 @@
     <value>comboPreamp</value>
   </data>
   <data name="&gt;&gt;comboPreamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboPreamp.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -3370,7 +3370,7 @@
     <value>lblRF</value>
   </data>
   <data name="&gt;&gt;lblRF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -3415,7 +3415,7 @@
     <value>chkShowTXFilter</value>
   </data>
   <data name="&gt;&gt;chkShowTXFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkShowTXFilter.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3463,7 +3463,7 @@
     <value>chkDX</value>
   </data>
   <data name="&gt;&gt;chkDX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkDX.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -3508,7 +3508,7 @@
     <value>chkTXEQ</value>
   </data>
   <data name="&gt;&gt;chkTXEQ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkTXEQ.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3535,7 +3535,7 @@
     <value>comboTXProfile</value>
   </data>
   <data name="&gt;&gt;comboTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3580,7 +3580,7 @@
     <value>chkRXEQ</value>
   </data>
   <data name="&gt;&gt;chkRXEQ.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRXEQ.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3625,7 +3625,7 @@
     <value>chkCPDR</value>
   </data>
   <data name="&gt;&gt;chkCPDR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCPDR.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3670,7 +3670,7 @@
     <value>chkVAC1</value>
   </data>
   <data name="&gt;&gt;chkVAC1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVAC1.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -3715,7 +3715,7 @@
     <value>chkVOX</value>
   </data>
   <data name="&gt;&gt;chkVOX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVOX.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3760,7 +3760,7 @@
     <value>chkNoiseGate</value>
   </data>
   <data name="&gt;&gt;chkNoiseGate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkNoiseGate.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -3787,7 +3787,7 @@
     <value>comboDigTXProfile</value>
   </data>
   <data name="&gt;&gt;comboDigTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboDigTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -3820,7 +3820,7 @@
     <value>chkVACStereo</value>
   </data>
   <data name="&gt;&gt;chkVACStereo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVACStereo.Parent" xml:space="preserve">
     <value>grpVACStereo</value>
@@ -3877,7 +3877,7 @@
     <value>comboVACSampleRate</value>
   </data>
   <data name="&gt;&gt;comboVACSampleRate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboVACSampleRate.Parent" xml:space="preserve">
     <value>grpDIGSampleRate</value>
@@ -3925,7 +3925,7 @@
     <value>btnDisplayPanCenter</value>
   </data>
   <data name="&gt;&gt;btnDisplayPanCenter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnDisplayPanCenter.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -3970,7 +3970,7 @@
     <value>radModeAM</value>
   </data>
   <data name="&gt;&gt;radModeAM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeAM.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4015,7 +4015,7 @@
     <value>radModeLSB</value>
   </data>
   <data name="&gt;&gt;radModeLSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeLSB.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4060,7 +4060,7 @@
     <value>radModeSAM</value>
   </data>
   <data name="&gt;&gt;radModeSAM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeSAM.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4105,7 +4105,7 @@
     <value>radModeCWL</value>
   </data>
   <data name="&gt;&gt;radModeCWL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeCWL.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4150,7 +4150,7 @@
     <value>radModeDSB</value>
   </data>
   <data name="&gt;&gt;radModeDSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeDSB.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4195,7 +4195,7 @@
     <value>radModeUSB</value>
   </data>
   <data name="&gt;&gt;radModeUSB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeUSB.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4240,7 +4240,7 @@
     <value>radModeCWU</value>
   </data>
   <data name="&gt;&gt;radModeCWU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeCWU.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4285,7 +4285,7 @@
     <value>radModeFMN</value>
   </data>
   <data name="&gt;&gt;radModeFMN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeFMN.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4330,7 +4330,7 @@
     <value>radModeDIGU</value>
   </data>
   <data name="&gt;&gt;radModeDIGU.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeDIGU.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4375,7 +4375,7 @@
     <value>radModeDRM</value>
   </data>
   <data name="&gt;&gt;radModeDRM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeDRM.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4420,7 +4420,7 @@
     <value>radModeDIGL</value>
   </data>
   <data name="&gt;&gt;radModeDIGL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeDIGL.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4465,7 +4465,7 @@
     <value>radModeSPEC</value>
   </data>
   <data name="&gt;&gt;radModeSPEC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radModeSPEC.Parent" xml:space="preserve">
     <value>panelMode</value>
@@ -4504,7 +4504,7 @@
     <value>btnBandVHF</value>
   </data>
   <data name="&gt;&gt;btnBandVHF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnBandVHF.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -4546,7 +4546,7 @@
     <value>chkVFOATX</value>
   </data>
   <data name="&gt;&gt;chkVFOATX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOATX.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -4576,7 +4576,7 @@
     <value>txtWheelTune</value>
   </data>
   <data name="&gt;&gt;txtWheelTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtWheelTune.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4618,7 +4618,7 @@
     <value>chkVFOBTX</value>
   </data>
   <data name="&gt;&gt;chkVFOBTX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOBTX.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -4648,7 +4648,7 @@
     <value>comboMeterTXMode</value>
   </data>
   <data name="&gt;&gt;comboMeterTXMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboMeterTXMode.Parent" xml:space="preserve">
     <value>grpMultimeterMenus</value>
@@ -4675,7 +4675,7 @@
     <value>comboMeterRXMode</value>
   </data>
   <data name="&gt;&gt;comboMeterRXMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboMeterRXMode.Parent" xml:space="preserve">
     <value>grpMultimeterMenus</value>
@@ -4717,7 +4717,7 @@
     <value>chkSquelch</value>
   </data>
   <data name="&gt;&gt;chkSquelch.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkSquelch.Parent" xml:space="preserve">
     <value>$this</value>
@@ -4756,7 +4756,7 @@
     <value>btnMemoryQuickRestore</value>
   </data>
   <data name="&gt;&gt;btnMemoryQuickRestore.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnMemoryQuickRestore.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4798,7 +4798,7 @@
     <value>btnMemoryQuickSave</value>
   </data>
   <data name="&gt;&gt;btnMemoryQuickSave.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnMemoryQuickSave.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4825,7 +4825,7 @@
     <value>txtMemoryQuick</value>
   </data>
   <data name="&gt;&gt;txtMemoryQuick.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtMemoryQuick.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4873,7 +4873,7 @@
     <value>chkVFOLock</value>
   </data>
   <data name="&gt;&gt;chkVFOLock.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOLock.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4918,7 +4918,7 @@
     <value>chkVFOSync</value>
   </data>
   <data name="&gt;&gt;chkVFOSync.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOSync.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4957,7 +4957,7 @@
     <value>btnTuneStepChangeLarger</value>
   </data>
   <data name="&gt;&gt;btnTuneStepChangeLarger.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnTuneStepChangeLarger.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -4996,7 +4996,7 @@
     <value>btnTuneStepChangeSmaller</value>
   </data>
   <data name="&gt;&gt;btnTuneStepChangeSmaller.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnTuneStepChangeSmaller.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -5035,7 +5035,7 @@
     <value>chkSplitDisplay</value>
   </data>
   <data name="&gt;&gt;chkSplitDisplay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkSplitDisplay.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -5071,7 +5071,7 @@
     <value>comboDisplayModeTop</value>
   </data>
   <data name="&gt;&gt;comboDisplayModeTop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboDisplayModeTop.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -5107,7 +5107,7 @@
     <value>comboDisplayModeBottom</value>
   </data>
   <data name="&gt;&gt;comboDisplayModeBottom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboDisplayModeBottom.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -5134,7 +5134,7 @@
     <value>comboRX2MeterMode</value>
   </data>
   <data name="&gt;&gt;comboRX2MeterMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2MeterMode.Parent" xml:space="preserve">
     <value>grpRX2Meter</value>
@@ -5179,7 +5179,7 @@
     <value>chkRX2DisplayAVG</value>
   </data>
   <data name="&gt;&gt;chkRX2DisplayAVG.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2DisplayAVG.Parent" xml:space="preserve">
     <value>panelRX2Display</value>
@@ -5224,7 +5224,7 @@
     <value>radBand160</value>
   </data>
   <data name="&gt;&gt;radBand160.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand160.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5270,7 +5270,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBandGEN</value>
   </data>
   <data name="&gt;&gt;radBandGEN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5315,7 +5315,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBandWWV</value>
   </data>
   <data name="&gt;&gt;radBandWWV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandWWV.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5363,7 +5363,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand2</value>
   </data>
   <data name="&gt;&gt;radBand2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand2.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5408,7 +5408,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand6</value>
   </data>
   <data name="&gt;&gt;radBand6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand6.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5453,7 +5453,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand10</value>
   </data>
   <data name="&gt;&gt;radBand10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand10.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5498,7 +5498,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand12</value>
   </data>
   <data name="&gt;&gt;radBand12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand12.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5543,7 +5543,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand15</value>
   </data>
   <data name="&gt;&gt;radBand15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand15.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5588,7 +5588,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand17</value>
   </data>
   <data name="&gt;&gt;radBand17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand17.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5633,7 +5633,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand20</value>
   </data>
   <data name="&gt;&gt;radBand20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand20.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5678,7 +5678,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand30</value>
   </data>
   <data name="&gt;&gt;radBand30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand30.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5723,7 +5723,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand40</value>
   </data>
   <data name="&gt;&gt;radBand40.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand40.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5768,7 +5768,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand60</value>
   </data>
   <data name="&gt;&gt;radBand60.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand60.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5813,7 +5813,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radBand80</value>
   </data>
   <data name="&gt;&gt;radBand80.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBand80.Parent" xml:space="preserve">
     <value>panelBandHF</value>
@@ -5852,7 +5852,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbDisplayZoom</value>
   </data>
   <data name="&gt;&gt;ptbDisplayZoom.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbDisplayZoom.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -5891,7 +5891,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbDisplayPan</value>
   </data>
   <data name="&gt;&gt;ptbDisplayPan.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbDisplayPan.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -5927,7 +5927,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbPWR</value>
   </data>
   <data name="&gt;&gt;ptbPWR.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbPWR.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -5963,7 +5963,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRF</value>
   </data>
   <data name="&gt;&gt;ptbRF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -5999,7 +5999,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbAF</value>
   </data>
   <data name="&gt;&gt;ptbAF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbAF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -6035,7 +6035,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbPanMainRX</value>
   </data>
   <data name="&gt;&gt;ptbPanMainRX.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbPanMainRX.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -6071,7 +6071,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbPanSubRX</value>
   </data>
   <data name="&gt;&gt;ptbPanSubRX.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbPanSubRX.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -6104,7 +6104,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX2Gain</value>
   </data>
   <data name="&gt;&gt;ptbRX2Gain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2Gain.Parent" xml:space="preserve">
     <value>panelRX2Mixer</value>
@@ -6137,7 +6137,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX2Pan</value>
   </data>
   <data name="&gt;&gt;ptbRX2Pan.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2Pan.Parent" xml:space="preserve">
     <value>panelRX2Mixer</value>
@@ -6170,7 +6170,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX0Gain</value>
   </data>
   <data name="&gt;&gt;ptbRX0Gain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX0Gain.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -6203,7 +6203,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX1Gain</value>
   </data>
   <data name="&gt;&gt;ptbRX1Gain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX1Gain.Parent" xml:space="preserve">
     <value>panelMultiRX</value>
@@ -6236,7 +6236,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbVACRXGain</value>
   </data>
   <data name="&gt;&gt;ptbVACRXGain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbVACRXGain.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -6269,7 +6269,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbVACTXGain</value>
   </data>
   <data name="&gt;&gt;ptbVACTXGain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbVACTXGain.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -6320,7 +6320,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radDisplayZoom05</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom05.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom05.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -6371,7 +6371,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radDisplayZoom4x</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom4x.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom4x.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -6422,7 +6422,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radDisplayZoom2x</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom2x.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom2x.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -6473,7 +6473,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radDisplayZoom1x</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom1x.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radDisplayZoom1x.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -6518,7 +6518,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkMicMute</value>
   </data>
   <data name="&gt;&gt;chkMicMute.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkMicMute.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -6563,7 +6563,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkMUT</value>
   </data>
   <data name="&gt;&gt;chkMUT.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkMUT.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -6602,7 +6602,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkCWFWKeyer</value>
   </data>
   <data name="&gt;&gt;chkCWFWKeyer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCWFWKeyer.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -6638,7 +6638,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkShowCWZero</value>
   </data>
   <data name="&gt;&gt;chkShowCWZero.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkShowCWZero.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -6683,7 +6683,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radFMDeviation5kHz</value>
   </data>
   <data name="&gt;&gt;radFMDeviation5kHz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFMDeviation5kHz.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6710,7 +6710,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>comboFMTXProfile</value>
   </data>
   <data name="&gt;&gt;comboFMTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboFMTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6734,7 +6734,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>udFMOffset</value>
   </data>
   <data name="&gt;&gt;udFMOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udFMOffset.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6779,7 +6779,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMTXSimplex</value>
   </data>
   <data name="&gt;&gt;chkFMTXSimplex.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMTXSimplex.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6803,7 +6803,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>comboFMCTCSS</value>
   </data>
   <data name="&gt;&gt;comboFMCTCSS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboFMCTCSS.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6842,7 +6842,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>btnFMMemory</value>
   </data>
   <data name="&gt;&gt;btnFMMemory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnFMMemory.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6887,7 +6887,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMCTCSS</value>
   </data>
   <data name="&gt;&gt;chkFMCTCSS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMCTCSS.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6929,7 +6929,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>btnFMMemoryUp</value>
   </data>
   <data name="&gt;&gt;btnFMMemoryUp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnFMMemoryUp.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -6971,7 +6971,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>btnFMMemoryDown</value>
   </data>
   <data name="&gt;&gt;btnFMMemoryDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnFMMemoryDown.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7016,7 +7016,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>radFMDeviation2kHz</value>
   </data>
   <data name="&gt;&gt;radFMDeviation2kHz.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFMDeviation2kHz.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7061,7 +7061,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMTXLow</value>
   </data>
   <data name="&gt;&gt;chkFMTXLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMTXLow.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7106,7 +7106,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMTXHigh</value>
   </data>
   <data name="&gt;&gt;chkFMTXHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMTXHigh.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7154,7 +7154,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkFMTXRev</value>
   </data>
   <data name="&gt;&gt;chkFMTXRev.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkFMTXRev.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -7199,7 +7199,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkTNF</value>
   </data>
   <data name="&gt;&gt;chkTNF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkTNF.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -7238,7 +7238,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>btnTNFAdd</value>
   </data>
   <data name="&gt;&gt;btnTNFAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnTNFAdd.Parent" xml:space="preserve">
     <value>panelDSP</value>
@@ -7274,7 +7274,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX2AF</value>
   </data>
   <data name="&gt;&gt;ptbRX2AF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2AF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -7310,7 +7310,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbRX1AF</value>
   </data>
   <data name="&gt;&gt;ptbRX1AF.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX1AF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -7352,7 +7352,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkVAC2</value>
   </data>
   <data name="&gt;&gt;chkVAC2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVAC2.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -7385,7 +7385,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkCWSidetone</value>
   </data>
   <data name="&gt;&gt;chkCWSidetone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCWSidetone.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -7412,7 +7412,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>udRX1StepAttData</value>
   </data>
   <data name="&gt;&gt;udRX1StepAttData.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRX1StepAttData.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -7439,7 +7439,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>comboRX2Preamp</value>
   </data>
   <data name="&gt;&gt;comboRX2Preamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboRX2Preamp.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -7466,7 +7466,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>udRX2StepAttData</value>
   </data>
   <data name="&gt;&gt;udRX2StepAttData.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udRX2StepAttData.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -7511,7 +7511,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>chkCWAPFEnabled</value>
   </data>
   <data name="&gt;&gt;chkCWAPFEnabled.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkCWAPFEnabled.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -7547,7 +7547,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbCWAPFGain</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFGain.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFGain.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -7583,7 +7583,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbCWAPFBandwidth</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFBandwidth.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFBandwidth.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -7619,7 +7619,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>ptbCWAPFFreq</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFFreq.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCWAPFFreq.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -7656,7 +7656,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>lblBandStack</value>
   </data>
   <data name="&gt;&gt;lblBandStack.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblBandStack.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -7689,7 +7689,7 @@ CTRL + Right Click on any Band Button to add Band Stack.</value>
     <value>regBandStackCurrentEntry</value>
   </data>
   <data name="&gt;&gt;regBandStackCurrentEntry.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;regBandStackCurrentEntry.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -7723,7 +7723,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>regBandStackTotalEntries</value>
   </data>
   <data name="&gt;&gt;regBandStackTotalEntries.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;regBandStackTotalEntries.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -7771,7 +7771,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN13</value>
   </data>
   <data name="&gt;&gt;radBandGEN13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN13.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -7819,7 +7819,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN12</value>
   </data>
   <data name="&gt;&gt;radBandGEN12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN12.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -7867,7 +7867,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN11</value>
   </data>
   <data name="&gt;&gt;radBandGEN11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN11.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -7915,7 +7915,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN10</value>
   </data>
   <data name="&gt;&gt;radBandGEN10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN10.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -7963,7 +7963,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN9</value>
   </data>
   <data name="&gt;&gt;radBandGEN9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN9.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8011,7 +8011,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN8</value>
   </data>
   <data name="&gt;&gt;radBandGEN8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN8.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8059,7 +8059,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN7</value>
   </data>
   <data name="&gt;&gt;radBandGEN7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN7.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8107,7 +8107,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN6</value>
   </data>
   <data name="&gt;&gt;radBandGEN6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN6.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8155,7 +8155,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN5</value>
   </data>
   <data name="&gt;&gt;radBandGEN5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN5.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8203,7 +8203,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN4</value>
   </data>
   <data name="&gt;&gt;radBandGEN4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN4.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8251,7 +8251,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN3</value>
   </data>
   <data name="&gt;&gt;radBandGEN3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN3.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8299,7 +8299,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN2</value>
   </data>
   <data name="&gt;&gt;radBandGEN2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN2.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8347,7 +8347,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN1</value>
   </data>
   <data name="&gt;&gt;radBandGEN1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN1.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8395,7 +8395,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandGEN0</value>
   </data>
   <data name="&gt;&gt;radBandGEN0.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandGEN0.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -8422,7 +8422,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>udTXFilterLow</value>
   </data>
   <data name="&gt;&gt;udTXFilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udTXFilterLow.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -8449,7 +8449,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>udTXFilterHigh</value>
   </data>
   <data name="&gt;&gt;udTXFilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;udTXFilterHigh.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -8494,7 +8494,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>chkRxAnt</value>
   </data>
   <data name="&gt;&gt;chkRxAnt.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRxAnt.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -8542,7 +8542,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>chkVFOBLock</value>
   </data>
   <data name="&gt;&gt;chkVFOBLock.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkVFOBLock.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -8587,7 +8587,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>chkQSK</value>
   </data>
   <data name="&gt;&gt;chkQSK.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkQSK.Parent" xml:space="preserve">
     <value>grpSemiBreakIn</value>
@@ -8614,7 +8614,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>comboAMTXProfile</value>
   </data>
   <data name="&gt;&gt;comboAMTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboAMTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -8659,7 +8659,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnDisplayZTB</value>
   </data>
   <data name="&gt;&gt;btnDisplayZTB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnDisplayZTB.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -8695,13 +8695,52 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbTune</value>
   </data>
   <data name="&gt;&gt;ptbTune.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbTune.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
   </data>
   <data name="&gt;&gt;ptbTune.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="lblPAProfile.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 6.75pt</value>
+  </data>
+  <data name="lblPAProfile.Image" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
+  <data name="lblPAProfile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>Off</value>
+  </data>
+  <data name="lblPAProfile.Location" type="System.Drawing.Point, System.Drawing">
+    <value>509, 570</value>
+  </data>
+  <data name="lblPAProfile.Size" type="System.Drawing.Size, System.Drawing">
+    <value>200, 14</value>
+  </data>
+  <data name="lblPAProfile.TabIndex" type="System.Int32, mscorlib">
+    <value>126</value>
+  </data>
+  <data name="lblPAProfile.Text" xml:space="preserve">
+    <value>PA Profile</value>
+  </data>
+  <data name="lblPAProfile.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="lblPAProfile.ToolTip" xml:space="preserve">
+    <value>The currently active PA profile. Right click to view settings.</value>
+  </data>
+  <data name="&gt;&gt;lblPAProfile.Name" xml:space="preserve">
+    <value>lblPAProfile</value>
+  </data>
+  <data name="&gt;&gt;lblPAProfile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;lblPAProfile.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;lblPAProfile.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="picSquelch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>Off</value>
@@ -10100,45 +10139,6 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
   <metadata name="tmrAutoAGC.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>589, 54</value>
   </metadata>
-  <data name="lblPAProfile.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 6.75pt</value>
-  </data>
-  <data name="lblPAProfile.Image" type="System.Resources.ResXNullRef, System.Windows.Forms">
-    <value />
-  </data>
-  <data name="lblPAProfile.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>Off</value>
-  </data>
-  <data name="lblPAProfile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>509, 570</value>
-  </data>
-  <data name="lblPAProfile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 14</value>
-  </data>
-  <data name="lblPAProfile.TabIndex" type="System.Int32, mscorlib">
-    <value>126</value>
-  </data>
-  <data name="lblPAProfile.Text" xml:space="preserve">
-    <value>PA Profile</value>
-  </data>
-  <data name="lblPAProfile.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="lblPAProfile.ToolTip" xml:space="preserve">
-    <value>The currently active PA profile. Right click to view settings.</value>
-  </data>
-  <data name="&gt;&gt;lblPAProfile.Name" xml:space="preserve">
-    <value>lblPAProfile</value>
-  </data>
-  <data name="&gt;&gt;lblPAProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;lblPAProfile.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;lblPAProfile.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="nudPwrTemp2.Location" type="System.Drawing.Point, System.Drawing">
     <value>86, 547</value>
   </data>
@@ -10155,7 +10155,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>nudPwrTemp2</value>
   </data>
   <data name="&gt;&gt;nudPwrTemp2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;nudPwrTemp2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10179,7 +10179,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>nudPwrTemp</value>
   </data>
   <data name="&gt;&gt;nudPwrTemp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.NumericUpDownTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;nudPwrTemp.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10206,7 +10206,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>pnlResizeMeter</value>
   </data>
   <data name="&gt;&gt;pnlResizeMeter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;pnlResizeMeter.Parent" xml:space="preserve">
     <value>grpMultimeter</value>
@@ -10263,7 +10263,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtMultiText</value>
   </data>
   <data name="&gt;&gt;txtMultiText.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtMultiText.Parent" xml:space="preserve">
     <value>grpMultimeter</value>
@@ -10287,7 +10287,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpMultimeter</value>
   </data>
   <data name="&gt;&gt;grpMultimeter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpMultimeter.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10335,7 +10335,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter1</value>
   </data>
   <data name="&gt;&gt;radFilter1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter1.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10368,7 +10368,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterHigh</value>
   </data>
   <data name="&gt;&gt;lblFilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterHigh.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10398,7 +10398,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterWidth</value>
   </data>
   <data name="&gt;&gt;lblFilterWidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterWidth.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10440,7 +10440,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilterVar2</value>
   </data>
   <data name="&gt;&gt;radFilterVar2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilterVar2.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10473,7 +10473,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterLow</value>
   </data>
   <data name="&gt;&gt;lblFilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterLow.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10515,7 +10515,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilterVar1</value>
   </data>
   <data name="&gt;&gt;radFilterVar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilterVar1.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10545,7 +10545,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterShift</value>
   </data>
   <data name="&gt;&gt;lblFilterShift.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterShift.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10587,7 +10587,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter9</value>
   </data>
   <data name="&gt;&gt;radFilter9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter9.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10629,7 +10629,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter8</value>
   </data>
   <data name="&gt;&gt;radFilter8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter8.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10671,7 +10671,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter2</value>
   </data>
   <data name="&gt;&gt;radFilter2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter2.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10713,7 +10713,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter7</value>
   </data>
   <data name="&gt;&gt;radFilter7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter7.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10755,7 +10755,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter3</value>
   </data>
   <data name="&gt;&gt;radFilter3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter3.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10797,7 +10797,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter6</value>
   </data>
   <data name="&gt;&gt;radFilter6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter6.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10839,7 +10839,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter4</value>
   </data>
   <data name="&gt;&gt;radFilter4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter4.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10881,7 +10881,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter5</value>
   </data>
   <data name="&gt;&gt;radFilter5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter5.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10923,7 +10923,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radFilter10</value>
   </data>
   <data name="&gt;&gt;radFilter10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radFilter10.Parent" xml:space="preserve">
     <value>panelFilter</value>
@@ -10947,7 +10947,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelFilter</value>
   </data>
   <data name="&gt;&gt;panelFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelFilter.Parent" xml:space="preserve">
     <value>$this</value>
@@ -10974,7 +10974,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2RF</value>
   </data>
   <data name="&gt;&gt;panelRX2RF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2RF.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11007,7 +11007,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbRX2Squelch</value>
   </data>
   <data name="&gt;&gt;ptbRX2Squelch.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbRX2Squelch.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11034,7 +11034,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2DSP</value>
   </data>
   <data name="&gt;&gt;panelRX2DSP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2DSP.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11064,7 +11064,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnHidden</value>
   </data>
   <data name="&gt;&gt;btnHidden.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnHidden.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11115,7 +11115,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>checkBoxTS1</value>
   </data>
   <data name="&gt;&gt;checkBoxTS1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;checkBoxTS1.Parent" xml:space="preserve">
     <value>panelOptions</value>
@@ -11139,7 +11139,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelOptions</value>
   </data>
   <data name="&gt;&gt;panelOptions.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelOptions.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11178,7 +11178,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar8</value>
   </data>
   <data name="&gt;&gt;btnAndrBar8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar8.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11211,7 +11211,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar7</value>
   </data>
   <data name="&gt;&gt;btnAndrBar7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar7.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11244,7 +11244,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar6</value>
   </data>
   <data name="&gt;&gt;btnAndrBar6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar6.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11277,7 +11277,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar5</value>
   </data>
   <data name="&gt;&gt;btnAndrBar5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar5.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11310,7 +11310,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar4</value>
   </data>
   <data name="&gt;&gt;btnAndrBar4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar4.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11343,7 +11343,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar3</value>
   </data>
   <data name="&gt;&gt;btnAndrBar3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar3.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11376,7 +11376,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar2</value>
   </data>
   <data name="&gt;&gt;btnAndrBar2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar2.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11409,7 +11409,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnAndrBar1</value>
   </data>
   <data name="&gt;&gt;btnAndrBar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnAndrBar1.Parent" xml:space="preserve">
     <value>panelButtonBar</value>
@@ -11433,7 +11433,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelButtonBar</value>
   </data>
   <data name="&gt;&gt;panelButtonBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelButtonBar.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11472,7 +11472,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblStepValue</value>
   </data>
   <data name="&gt;&gt;lblStepValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblStepValue.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11505,7 +11505,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblStep</value>
   </data>
   <data name="&gt;&gt;lblStep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblStep.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11541,7 +11541,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVFOSplit</value>
   </data>
   <data name="&gt;&gt;lblVFOSplit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVFOSplit.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11574,7 +11574,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblXITValue</value>
   </data>
   <data name="&gt;&gt;lblXITValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblXITValue.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11607,7 +11607,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRITValue</value>
   </data>
   <data name="&gt;&gt;lblRITValue.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRITValue.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11640,7 +11640,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRITLabel</value>
   </data>
   <data name="&gt;&gt;lblRITLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRITLabel.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11673,7 +11673,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblXITLabel</value>
   </data>
   <data name="&gt;&gt;lblXITLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblXITLabel.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11709,7 +11709,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVFOSyncLabel</value>
   </data>
   <data name="&gt;&gt;lblVFOSyncLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVFOSyncLabel.Parent" xml:space="preserve">
     <value>panelVFOLabels</value>
@@ -11733,7 +11733,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelVFOLabels</value>
   </data>
   <data name="&gt;&gt;panelVFOLabels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelVFOLabels.Parent" xml:space="preserve">
     <value>$this</value>
@@ -11775,7 +11775,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblLockLabel</value>
   </data>
   <data name="&gt;&gt;lblLockLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblLockLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11811,7 +11811,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAGCLabel</value>
   </data>
   <data name="&gt;&gt;lblAGCLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAGCLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11847,7 +11847,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAttenLabel</value>
   </data>
   <data name="&gt;&gt;lblAttenLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAttenLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11880,7 +11880,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblANFLabel</value>
   </data>
   <data name="&gt;&gt;lblANFLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblANFLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11913,7 +11913,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblSNBLabel</value>
   </data>
   <data name="&gt;&gt;lblSNBLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblSNBLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11946,7 +11946,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblNBLabel</value>
   </data>
   <data name="&gt;&gt;lblNBLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblNBLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -11979,7 +11979,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblNRLabel</value>
   </data>
   <data name="&gt;&gt;lblNRLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblNRLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -12015,7 +12015,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCtunLabel</value>
   </data>
   <data name="&gt;&gt;lblCtunLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCtunLabel.Parent" xml:space="preserve">
     <value>panelVFOALabels</value>
@@ -12039,7 +12039,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelVFOALabels</value>
   </data>
   <data name="&gt;&gt;panelVFOALabels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelVFOALabels.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12081,7 +12081,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2AttenLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2AttenLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2AttenLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12117,7 +12117,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2LockLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2LockLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2LockLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12153,7 +12153,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2AGCLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2AGCLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2AGCLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12189,7 +12189,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2CtunLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2CtunLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2CtunLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12222,7 +12222,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2NRLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2NRLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2NRLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12255,7 +12255,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2NBLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2NBLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2NBLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12288,7 +12288,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2SNBLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2SNBLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2SNBLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12321,7 +12321,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2ANFLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2ANFLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2ANFLabel.Parent" xml:space="preserve">
     <value>panelVFOBLabels</value>
@@ -12345,7 +12345,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelVFOBLabels</value>
   </data>
   <data name="&gt;&gt;panelVFOBLabels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelVFOBLabels.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12384,7 +12384,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2Band</value>
   </data>
   <data name="&gt;&gt;lblRX2Band.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2Band.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -12417,7 +12417,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2Preamp</value>
   </data>
   <data name="&gt;&gt;lblRX2Preamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2Preamp.Parent" xml:space="preserve">
     <value>panelRX2Power</value>
@@ -12438,7 +12438,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Power</value>
   </data>
   <data name="&gt;&gt;panelRX2Power.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Power.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12474,7 +12474,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>chkRX2</value>
   </data>
   <data name="&gt;&gt;chkRX2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.CheckBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;chkRX2.Parent" xml:space="preserve">
     <value>panelPower</value>
@@ -12507,7 +12507,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX1Show</value>
   </data>
   <data name="&gt;&gt;radRX1Show.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX1Show.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -12543,7 +12543,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Show</value>
   </data>
   <data name="&gt;&gt;radRX2Show.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Show.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -12579,7 +12579,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRF2</value>
   </data>
   <data name="&gt;&gt;lblRF2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRF2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12606,7 +12606,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelPower</value>
   </data>
   <data name="&gt;&gt;panelPower.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelPower.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12642,7 +12642,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWAPFGain</value>
   </data>
   <data name="&gt;&gt;lblCWAPFGain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWAPFGain.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -12672,7 +12672,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWAPFBandwidth</value>
   </data>
   <data name="&gt;&gt;lblCWAPFBandwidth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWAPFBandwidth.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -12702,7 +12702,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWAPFTune</value>
   </data>
   <data name="&gt;&gt;lblCWAPFTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWAPFTune.Parent" xml:space="preserve">
     <value>grpCWAPF</value>
@@ -12726,7 +12726,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpCWAPF</value>
   </data>
   <data name="&gt;&gt;grpCWAPF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpCWAPF.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -12756,7 +12756,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWSpeed</value>
   </data>
   <data name="&gt;&gt;lblCWSpeed.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWSpeed.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -12786,7 +12786,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWBreakInDelay</value>
   </data>
   <data name="&gt;&gt;lblCWBreakInDelay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWBreakInDelay.Parent" xml:space="preserve">
     <value>grpSemiBreakIn</value>
@@ -12810,7 +12810,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpSemiBreakIn</value>
   </data>
   <data name="&gt;&gt;grpSemiBreakIn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpSemiBreakIn.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -12840,7 +12840,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCWPitchFreq</value>
   </data>
   <data name="&gt;&gt;lblCWPitchFreq.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCWPitchFreq.Parent" xml:space="preserve">
     <value>panelModeSpecificCW</value>
@@ -12861,7 +12861,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelModeSpecificCW</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificCW.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificCW.Parent" xml:space="preserve">
     <value>$this</value>
@@ -12909,7 +12909,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter1</value>
   </data>
   <data name="&gt;&gt;radRX2Filter1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter1.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -12942,7 +12942,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2FilterHigh</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterHigh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterHigh.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -12975,7 +12975,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2FilterLow</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterLow.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterLow.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13017,7 +13017,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter2</value>
   </data>
   <data name="&gt;&gt;radRX2Filter2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter2.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13059,7 +13059,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2FilterVar2</value>
   </data>
   <data name="&gt;&gt;radRX2FilterVar2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2FilterVar2.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13101,7 +13101,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter3</value>
   </data>
   <data name="&gt;&gt;radRX2Filter3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter3.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13143,7 +13143,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2FilterVar1</value>
   </data>
   <data name="&gt;&gt;radRX2FilterVar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2FilterVar1.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13185,7 +13185,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter4</value>
   </data>
   <data name="&gt;&gt;radRX2Filter4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter4.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13227,7 +13227,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter7</value>
   </data>
   <data name="&gt;&gt;radRX2Filter7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter7.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13269,7 +13269,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter5</value>
   </data>
   <data name="&gt;&gt;radRX2Filter5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter5.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13311,7 +13311,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radRX2Filter6</value>
   </data>
   <data name="&gt;&gt;radRX2Filter6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radRX2Filter6.Parent" xml:space="preserve">
     <value>panelRX2Filter</value>
@@ -13332,7 +13332,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Filter</value>
   </data>
   <data name="&gt;&gt;panelRX2Filter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Filter.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13359,7 +13359,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Mode</value>
   </data>
   <data name="&gt;&gt;panelRX2Mode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Mode.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13386,7 +13386,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Display</value>
   </data>
   <data name="&gt;&gt;panelRX2Display.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Display.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13473,7 +13473,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelRX2Mixer</value>
   </data>
   <data name="&gt;&gt;panelRX2Mixer.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelRX2Mixer.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13590,7 +13590,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelMultiRX</value>
   </data>
   <data name="&gt;&gt;panelMultiRX.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelMultiRX.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13620,7 +13620,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelDisplay2</value>
   </data>
   <data name="&gt;&gt;panelDisplay2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelDisplay2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13650,7 +13650,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelDSP</value>
   </data>
   <data name="&gt;&gt;panelDSP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelDSP.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13686,7 +13686,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ucVAC2UnderOver</value>
   </data>
   <data name="&gt;&gt;ucVAC2UnderOver.Type" xml:space="preserve">
-    <value>Thetis.ucUnderOverFlowWarningViewer, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.ucUnderOverFlowWarningViewer, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ucVAC2UnderOver.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -13716,7 +13716,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ucVAC1UnderOver</value>
   </data>
   <data name="&gt;&gt;ucVAC1UnderOver.Type" xml:space="preserve">
-    <value>Thetis.ucUnderOverFlowWarningViewer, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.ucUnderOverFlowWarningViewer, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ucVAC1UnderOver.Parent" xml:space="preserve">
     <value>panelVFO</value>
@@ -13740,7 +13740,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelVFO</value>
   </data>
   <data name="&gt;&gt;panelVFO.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelVFO.Parent" xml:space="preserve">
     <value>$this</value>
@@ -13779,7 +13779,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblTune</value>
   </data>
   <data name="&gt;&gt;lblTune.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTune.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13812,7 +13812,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2AF</value>
   </data>
   <data name="&gt;&gt;lblRX2AF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2AF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13845,7 +13845,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX1AF</value>
   </data>
   <data name="&gt;&gt;lblRX1AF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX1AF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13878,7 +13878,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAF</value>
   </data>
   <data name="&gt;&gt;lblAF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAF.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13911,7 +13911,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblPWR</value>
   </data>
   <data name="&gt;&gt;lblPWR.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblPWR.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13944,7 +13944,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblPreamp</value>
   </data>
   <data name="&gt;&gt;lblPreamp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblPreamp.Parent" xml:space="preserve">
     <value>panelSoundControls</value>
@@ -13965,7 +13965,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelSoundControls</value>
   </data>
   <data name="&gt;&gt;panelSoundControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelSoundControls.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14001,7 +14001,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAF2</value>
   </data>
   <data name="&gt;&gt;lblAF2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAF2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14040,7 +14040,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblPWR2</value>
   </data>
   <data name="&gt;&gt;lblPWR2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblPWR2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14079,7 +14079,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS4</value>
   </data>
   <data name="&gt;&gt;labelTS4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS4.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14115,7 +14115,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS3</value>
   </data>
   <data name="&gt;&gt;labelTS3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS3.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14181,7 +14181,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblNoiseGateVal</value>
   </data>
   <data name="&gt;&gt;lblNoiseGateVal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblNoiseGateVal.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14220,7 +14220,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbNoiseGate</value>
   </data>
   <data name="&gt;&gt;ptbNoiseGate.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbNoiseGate.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14277,7 +14277,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbVOX</value>
   </data>
   <data name="&gt;&gt;ptbVOX.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbVOX.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14313,7 +14313,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVOXVal</value>
   </data>
   <data name="&gt;&gt;lblVOXVal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVOXVal.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14346,7 +14346,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbCPDR</value>
   </data>
   <data name="&gt;&gt;ptbCPDR.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbCPDR.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14382,7 +14382,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblCPDRVal</value>
   </data>
   <data name="&gt;&gt;lblCPDRVal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblCPDRVal.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14418,7 +14418,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblMicVal</value>
   </data>
   <data name="&gt;&gt;lblMicVal.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblMicVal.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14451,7 +14451,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbMic</value>
   </data>
   <data name="&gt;&gt;ptbMic.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbMic.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14490,7 +14490,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblMIC</value>
   </data>
   <data name="&gt;&gt;lblMIC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblMIC.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14523,7 +14523,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblTransmitProfile</value>
   </data>
   <data name="&gt;&gt;lblTransmitProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTransmitProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificPhone</value>
@@ -14544,7 +14544,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelModeSpecificPhone</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificPhone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificPhone.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14580,7 +14580,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVACTXIndicator</value>
   </data>
   <data name="&gt;&gt;lblVACTXIndicator.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVACTXIndicator.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14610,7 +14610,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVACRXIndicator</value>
   </data>
   <data name="&gt;&gt;lblVACRXIndicator.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVACRXIndicator.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14643,7 +14643,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDigTXProfile</value>
   </data>
   <data name="&gt;&gt;lblDigTXProfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDigTXProfile.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14673,7 +14673,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRXGain</value>
   </data>
   <data name="&gt;&gt;lblRXGain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRXGain.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14697,7 +14697,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpVACStereo</value>
   </data>
   <data name="&gt;&gt;grpVACStereo.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpVACStereo.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14727,7 +14727,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblTXGain</value>
   </data>
   <data name="&gt;&gt;lblTXGain.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTXGain.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14751,7 +14751,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpDIGSampleRate</value>
   </data>
   <data name="&gt;&gt;grpDIGSampleRate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpDIGSampleRate.Parent" xml:space="preserve">
     <value>panelModeSpecificDigital</value>
@@ -14775,7 +14775,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelModeSpecificDigital</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificDigital.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificDigital.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14814,7 +14814,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>infoBar</value>
   </data>
   <data name="&gt;&gt;infoBar.Type" xml:space="preserve">
-    <value>Thetis.ucInfoBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.ucInfoBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;infoBar.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -14853,7 +14853,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDisplayZoom</value>
   </data>
   <data name="&gt;&gt;lblDisplayZoom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDisplayZoom.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -14892,7 +14892,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDisplayPan</value>
   </data>
   <data name="&gt;&gt;lblDisplayPan.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDisplayPan.Parent" xml:space="preserve">
     <value>panelDisplay</value>
@@ -14952,7 +14952,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelDisplay</value>
   </data>
   <data name="&gt;&gt;panelDisplay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelDisplay.Parent" xml:space="preserve">
     <value>$this</value>
@@ -14985,7 +14985,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelMode</value>
   </data>
   <data name="&gt;&gt;panelMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelMode.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15015,7 +15015,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelBandHF</value>
   </data>
   <data name="&gt;&gt;panelBandHF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelBandHF.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15045,7 +15045,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOAFreq</value>
   </data>
   <data name="&gt;&gt;txtVFOAFreq.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOAFreq.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15108,7 +15108,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblModeBigLabel</value>
   </data>
   <data name="&gt;&gt;lblModeBigLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblModeBigLabel.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15144,7 +15144,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX1APF</value>
   </data>
   <data name="&gt;&gt;lblRX1APF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX1APF.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15177,7 +15177,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX1MuteVFOA</value>
   </data>
   <data name="&gt;&gt;lblRX1MuteVFOA.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX1MuteVFOA.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15219,7 +15219,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFilterLabel</value>
   </data>
   <data name="&gt;&gt;lblFilterLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFilterLabel.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15261,7 +15261,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblModeLabel</value>
   </data>
   <data name="&gt;&gt;lblModeLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblModeLabel.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15291,7 +15291,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOALSD</value>
   </data>
   <data name="&gt;&gt;txtVFOALSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOALSD.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15321,7 +15321,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOAMSD</value>
   </data>
   <data name="&gt;&gt;txtVFOAMSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOAMSD.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15375,7 +15375,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOABand</value>
   </data>
   <data name="&gt;&gt;txtVFOABand.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOABand.Parent" xml:space="preserve">
     <value>grpVFOA</value>
@@ -15402,7 +15402,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpVFOA</value>
   </data>
   <data name="&gt;&gt;grpVFOA.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpVFOA.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15444,7 +15444,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2ModeBigLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2ModeBigLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2ModeBigLabel.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15480,7 +15480,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2APF</value>
   </data>
   <data name="&gt;&gt;lblRX2APF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2APF.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15531,7 +15531,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOBBand</value>
   </data>
   <data name="&gt;&gt;txtVFOBBand.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOBBand.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15561,7 +15561,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOBLSD</value>
   </data>
   <data name="&gt;&gt;txtVFOBLSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOBLSD.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15603,7 +15603,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2FilterLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2FilterLabel.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15636,7 +15636,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2MuteVFOB</value>
   </data>
   <data name="&gt;&gt;lblRX2MuteVFOB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2MuteVFOB.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15678,7 +15678,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRX2ModeLabel</value>
   </data>
   <data name="&gt;&gt;lblRX2ModeLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRX2ModeLabel.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15708,7 +15708,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOBMSD</value>
   </data>
   <data name="&gt;&gt;txtVFOBMSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOBMSD.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15750,7 +15750,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblVFOBLSD</value>
   </data>
   <data name="&gt;&gt;lblVFOBLSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblVFOBLSD.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15780,7 +15780,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtVFOBFreq</value>
   </data>
   <data name="&gt;&gt;txtVFOBFreq.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtVFOBFreq.Parent" xml:space="preserve">
     <value>grpVFOB</value>
@@ -15807,7 +15807,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpVFOB</value>
   </data>
   <data name="&gt;&gt;grpVFOB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpVFOB.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15843,7 +15843,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnBandHF</value>
   </data>
   <data name="&gt;&gt;btnBandHF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnBandHF.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -15873,7 +15873,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblTuneStep</value>
   </data>
   <data name="&gt;&gt;lblTuneStep.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblTuneStep.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -15894,7 +15894,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ucQuickRecallPad</value>
   </data>
   <data name="&gt;&gt;ucQuickRecallPad.Type" xml:space="preserve">
-    <value>Thetis.ucQuickRecall, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.ucQuickRecall, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ucQuickRecallPad.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -15924,7 +15924,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS1</value>
   </data>
   <data name="&gt;&gt;labelTS1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS1.Parent" xml:space="preserve">
     <value>grpVFOBetween</value>
@@ -15945,7 +15945,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpVFOBetween</value>
   </data>
   <data name="&gt;&gt;grpVFOBetween.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpVFOBetween.Parent" xml:space="preserve">
     <value>$this</value>
@@ -15975,7 +15975,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDisplayModeTop</value>
   </data>
   <data name="&gt;&gt;lblDisplayModeTop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDisplayModeTop.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -16005,7 +16005,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblDisplayModeBottom</value>
   </data>
   <data name="&gt;&gt;lblDisplayModeBottom.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblDisplayModeBottom.Parent" xml:space="preserve">
     <value>grpDisplaySplit</value>
@@ -16032,7 +16032,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpDisplaySplit</value>
   </data>
   <data name="&gt;&gt;grpDisplaySplit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpDisplaySplit.Parent" xml:space="preserve">
     <value>$this</value>
@@ -16089,7 +16089,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>txtRX2Meter</value>
   </data>
   <data name="&gt;&gt;txtRX2Meter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TextBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;txtRX2Meter.Parent" xml:space="preserve">
     <value>grpRX2Meter</value>
@@ -16113,7 +16113,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpRX2Meter</value>
   </data>
   <data name="&gt;&gt;grpRX2Meter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpRX2Meter.Parent" xml:space="preserve">
     <value>$this</value>
@@ -16164,7 +16164,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF13</value>
   </data>
   <data name="&gt;&gt;radBandVHF13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF13.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16209,7 +16209,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF12</value>
   </data>
   <data name="&gt;&gt;radBandVHF12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF12.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16254,7 +16254,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF11</value>
   </data>
   <data name="&gt;&gt;radBandVHF11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF11.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16299,7 +16299,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF10</value>
   </data>
   <data name="&gt;&gt;radBandVHF10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF10.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16344,7 +16344,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF9</value>
   </data>
   <data name="&gt;&gt;radBandVHF9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF9.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16389,7 +16389,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF8</value>
   </data>
   <data name="&gt;&gt;radBandVHF8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF8.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16434,7 +16434,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF7</value>
   </data>
   <data name="&gt;&gt;radBandVHF7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF7.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16479,7 +16479,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF6</value>
   </data>
   <data name="&gt;&gt;radBandVHF6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF6.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16524,7 +16524,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF5</value>
   </data>
   <data name="&gt;&gt;radBandVHF5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF5.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16569,7 +16569,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF4</value>
   </data>
   <data name="&gt;&gt;radBandVHF4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF4.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16614,7 +16614,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF3</value>
   </data>
   <data name="&gt;&gt;radBandVHF3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF3.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16659,7 +16659,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF2</value>
   </data>
   <data name="&gt;&gt;radBandVHF2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF2.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16704,7 +16704,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF1</value>
   </data>
   <data name="&gt;&gt;radBandVHF1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF1.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16749,7 +16749,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>radBandVHF0</value>
   </data>
   <data name="&gt;&gt;radBandVHF0.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.RadioButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;radBandVHF0.Parent" xml:space="preserve">
     <value>panelBandVHF</value>
@@ -16770,7 +16770,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelBandVHF</value>
   </data>
   <data name="&gt;&gt;panelBandVHF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelBandVHF.Parent" xml:space="preserve">
     <value>$this</value>
@@ -16803,7 +16803,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbSquelch</value>
   </data>
   <data name="&gt;&gt;ptbSquelch.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbSquelch.Parent" xml:space="preserve">
     <value>$this</value>
@@ -16842,7 +16842,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>ptbFMMic</value>
   </data>
   <data name="&gt;&gt;ptbFMMic.Type" xml:space="preserve">
-    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>Thetis.PrettyTrackBar, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;ptbFMMic.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16878,7 +16878,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblMicValFM</value>
   </data>
   <data name="&gt;&gt;lblMicValFM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblMicValFM.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16911,7 +16911,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>labelTS7</value>
   </data>
   <data name="&gt;&gt;labelTS7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;labelTS7.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16947,7 +16947,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFMOffset</value>
   </data>
   <data name="&gt;&gt;lblFMOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFMOffset.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -16983,7 +16983,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFMDeviation</value>
   </data>
   <data name="&gt;&gt;lblFMDeviation.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFMDeviation.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -17007,7 +17007,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>comboFMMemory</value>
   </data>
   <data name="&gt;&gt;comboFMMemory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ComboBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;comboFMMemory.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -17043,7 +17043,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblFMMic</value>
   </data>
   <data name="&gt;&gt;lblFMMic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblFMMic.Parent" xml:space="preserve">
     <value>panelModeSpecificFM</value>
@@ -17064,7 +17064,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelModeSpecificFM</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificFM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelModeSpecificFM.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17106,7 +17106,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>btnBandHF1</value>
   </data>
   <data name="&gt;&gt;btnBandHF1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.ButtonTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;btnBandHF1.Parent" xml:space="preserve">
     <value>panelBandGEN</value>
@@ -17127,7 +17127,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelBandGEN</value>
   </data>
   <data name="&gt;&gt;panelBandGEN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelBandGEN.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17169,7 +17169,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblRXMeter</value>
   </data>
   <data name="&gt;&gt;lblRXMeter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblRXMeter.Parent" xml:space="preserve">
     <value>panelMeterLabels</value>
@@ -17193,7 +17193,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelMeterLabels</value>
   </data>
   <data name="&gt;&gt;panelMeterLabels.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelMeterLabels.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17214,7 +17214,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>grpMultimeterMenus</value>
   </data>
   <data name="&gt;&gt;grpMultimeterMenus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.GroupBoxTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;grpMultimeterMenus.Parent" xml:space="preserve">
     <value>$this</value>
@@ -17250,7 +17250,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>tbAndromedaEncoderSlider</value>
   </data>
   <data name="&gt;&gt;tbAndromedaEncoderSlider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBarTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.TrackBarTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;tbAndromedaEncoderSlider.Parent" xml:space="preserve">
     <value>panelAndromedaMisc</value>
@@ -17286,7 +17286,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblAndromedaEncoderSlider</value>
   </data>
   <data name="&gt;&gt;lblAndromedaEncoderSlider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblAndromedaEncoderSlider.Parent" xml:space="preserve">
     <value>panelAndromedaMisc</value>
@@ -17322,7 +17322,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>lblATUTuneLabel</value>
   </data>
   <data name="&gt;&gt;lblATUTuneLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.LabelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;lblATUTuneLabel.Parent" xml:space="preserve">
     <value>panelAndromedaMisc</value>
@@ -17343,7 +17343,7 @@ Ctrl + Left Click on any Band Button adds to Stack</value>
     <value>panelAndromedaMisc</value>
   </data>
   <data name="&gt;&gt;panelAndromedaMisc.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.1.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.PanelTS, Thetis, Version=2.10.2.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;panelAndromedaMisc.Parent" xml:space="preserve">
     <value>$this</value>

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -2207,6 +2207,7 @@ namespace Thetis
             comboKBCWDot_SelectedIndexChanged(this, e);
             comboKBPTTTx_SelectedIndexChanged(this, e);
             comboKBPTTRx_SelectedIndexChanged(this, e);
+            radSpaceBarVFOBTX_CheckedChanged(this, e);
 
             // Appearance Tab
             clrbtnBtnSel_Changed(this, e);
@@ -2279,7 +2280,7 @@ namespace Thetis
             chkNoiseFloorShowDBM_CheckedChanged(this, e);
             udNoiseFloorLineWidth_ValueChanged(this, e);
 
-            //[2.10.1.0]MW0LGE mainly colours
+            //[2.10.1.0]MW0LGE
             clrbtnOutOfBand_Changed(this, e);
             chkVFOSmallLSD_CheckedChanged(this, e);
             clrbtnVFOSmallColor_Changed(this, e);
@@ -2288,6 +2289,8 @@ namespace Thetis
             clrbtnMeterBackground_Changed(this, e);
             clrbtnBandBackground_Changed(this, e);
             clrbtnVFOBackground_Changed(this, e);
+
+            chkLegacyMeters_CheckedChanged(this, e);
             //
 
             // RX2 tab
@@ -27089,6 +27092,20 @@ namespace Thetis
             if (initializing) return;
 
             console.SetMasterAFLinked(0, chkLinkMaster.Checked);
+        }
+
+        private void chkLegacyMeters_CheckedChanged(object sender, EventArgs e)
+        {
+            if (initializing) return;
+
+            console.UseLegacyMeters = chkLegacyMeters.Checked;
+        }
+
+        private void radSpaceBarVFOBTX_CheckedChanged(object sender, EventArgs e)
+        {
+            if (initializing) return;
+
+            console.SpaceBarVFOBTX = radSpaceBarVFOBTX.Checked;
         }
     }
 

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -1709,9 +1709,11 @@
             this.comboAudioDriver3 = new System.Windows.Forms.ComboBoxTS();
             this.chkVAC2Enable = new System.Windows.Forms.CheckBoxTS();
             this.tpAudioOptions = new System.Windows.Forms.TabPage();
+            this.groupBoxTS29 = new System.Windows.Forms.GroupBoxTS();
+            this.chkLinkMaster = new System.Windows.Forms.CheckBoxTS();
+            this.chkLinkRX0AF = new System.Windows.Forms.CheckBoxTS();
             this.chkLinkToRX2AF = new System.Windows.Forms.CheckBoxTS();
             this.chkLinkRX1AF = new System.Windows.Forms.CheckBoxTS();
-            this.chkLinkRX0AF = new System.Windows.Forms.CheckBoxTS();
             this.chkDisableRearSpeakerJacksAudioAmplifier = new System.Windows.Forms.CheckBoxTS();
             this.chkNoFadeOverUnderWarning = new System.Windows.Forms.CheckBoxTS();
             this.chkAFSlidersMute = new System.Windows.Forms.CheckBoxTS();
@@ -2921,6 +2923,7 @@
             this.clrbtnPeakText = new Thetis.ColorButton();
             this.lblPeakText = new System.Windows.Forms.LabelTS();
             this.tpAppearanceMeter = new System.Windows.Forms.TabPage();
+            this.chkLegacyMeters = new System.Windows.Forms.CheckBoxTS();
             this.groupBoxTS14 = new System.Windows.Forms.GroupBoxTS();
             this.tbSignalHistoryAlpha = new System.Windows.Forms.TrackBarTS();
             this.clrbtnSignalHistoryColour = new Thetis.ColorButton();
@@ -3468,8 +3471,7 @@
             this.radioButtonTS5 = new System.Windows.Forms.RadioButtonTS();
             this.radioButtonTS6 = new System.Windows.Forms.RadioButtonTS();
             this.tmrCheckProfile = new System.Windows.Forms.Timer(this.components);
-            this.groupBoxTS29 = new System.Windows.Forms.GroupBoxTS();
-            this.chkLinkMaster = new System.Windows.Forms.CheckBoxTS();
+            this.radSpaceBarVFOBTX = new System.Windows.Forms.RadioButtonTS();
             tpAlexAntCtrl = new System.Windows.Forms.TabPage();
             numericUpDownTS3 = new System.Windows.Forms.NumericUpDownTS();
             numericUpDownTS4 = new System.Windows.Forms.NumericUpDownTS();
@@ -3774,6 +3776,7 @@
             this.grpAudioBuffer3.SuspendLayout();
             this.grpAudioDetails3.SuspendLayout();
             this.tpAudioOptions.SuspendLayout();
+            this.groupBoxTS29.SuspendLayout();
             this.tpAdvancedAudio.SuspendLayout();
             this.grpVAC2ResamplerAdvanced.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udVAC2FFMinOut)).BeginInit();
@@ -4388,7 +4391,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS35)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS36)).BeginInit();
             this.panelTS4.SuspendLayout();
-            this.groupBoxTS29.SuspendLayout();
             this.SuspendLayout();
             // 
             // tpAlexAntCtrl
@@ -27733,41 +27735,67 @@
             this.tpAudioOptions.TabIndex = 4;
             this.tpAudioOptions.Text = "Options";
             // 
-            // chkLinkMasterToRX2
+            // groupBoxTS29
+            // 
+            this.groupBoxTS29.Controls.Add(this.chkLinkMaster);
+            this.groupBoxTS29.Controls.Add(this.chkLinkRX0AF);
+            this.groupBoxTS29.Controls.Add(this.chkLinkToRX2AF);
+            this.groupBoxTS29.Controls.Add(this.chkLinkRX1AF);
+            this.groupBoxTS29.Location = new System.Drawing.Point(19, 134);
+            this.groupBoxTS29.Name = "groupBoxTS29";
+            this.groupBoxTS29.Size = new System.Drawing.Size(200, 120);
+            this.groupBoxTS29.TabIndex = 6;
+            this.groupBoxTS29.TabStop = false;
+            this.groupBoxTS29.Text = "Linked AF Sliders";
+            this.toolTip1.SetToolTip(this.groupBoxTS29, "When one moves, the others move");
+            // 
+            // chkLinkMaster
+            // 
+            this.chkLinkMaster.AutoSize = true;
+            this.chkLinkMaster.Image = null;
+            this.chkLinkMaster.Location = new System.Drawing.Point(23, 24);
+            this.chkLinkMaster.Name = "chkLinkMaster";
+            this.chkLinkMaster.Size = new System.Drawing.Size(74, 17);
+            this.chkLinkMaster.TabIndex = 6;
+            this.chkLinkMaster.Text = "Master AF";
+            this.chkLinkMaster.UseVisualStyleBackColor = true;
+            this.chkLinkMaster.CheckedChanged += new System.EventHandler(this.chkLinkMaster_CheckedChanged);
+            // 
+            // chkLinkRX0AF
+            // 
+            this.chkLinkRX0AF.AutoSize = true;
+            this.chkLinkRX0AF.Image = null;
+            this.chkLinkRX0AF.Location = new System.Drawing.Point(23, 47);
+            this.chkLinkRX0AF.Name = "chkLinkRX0AF";
+            this.chkLinkRX0AF.Size = new System.Drawing.Size(63, 17);
+            this.chkLinkRX0AF.TabIndex = 3;
+            this.chkLinkRX0AF.Text = "RX1 AF";
+            this.chkLinkRX0AF.UseVisualStyleBackColor = true;
+            this.chkLinkRX0AF.CheckedChanged += new System.EventHandler(this.chkLinkRX0AF_CheckedChanged);
+            // 
+            // chkLinkToRX2AF
             // 
             this.chkLinkToRX2AF.AutoSize = true;
             this.chkLinkToRX2AF.Image = null;
             this.chkLinkToRX2AF.Location = new System.Drawing.Point(23, 70);
-            this.chkLinkToRX2AF.Name = "chkLinkMasterToRX2";
+            this.chkLinkToRX2AF.Name = "chkLinkToRX2AF";
             this.chkLinkToRX2AF.Size = new System.Drawing.Size(63, 17);
             this.chkLinkToRX2AF.TabIndex = 5;
             this.chkLinkToRX2AF.Text = "RX2 AF";
             this.chkLinkToRX2AF.UseVisualStyleBackColor = true;
             this.chkLinkToRX2AF.CheckedChanged += new System.EventHandler(this.chkLinkRX2AF_CheckedChanged);
             // 
-            // chkLinkMasterToRX1
+            // chkLinkRX1AF
             // 
             this.chkLinkRX1AF.AutoSize = true;
             this.chkLinkRX1AF.Image = null;
             this.chkLinkRX1AF.Location = new System.Drawing.Point(23, 93);
-            this.chkLinkRX1AF.Name = "chkLinkMasterToRX1";
+            this.chkLinkRX1AF.Name = "chkLinkRX1AF";
             this.chkLinkRX1AF.Size = new System.Drawing.Size(122, 17);
             this.chkLinkRX1AF.TabIndex = 4;
             this.chkLinkRX1AF.Text = "SubRX AF (MultiRX)";
             this.chkLinkRX1AF.UseVisualStyleBackColor = true;
             this.chkLinkRX1AF.CheckedChanged += new System.EventHandler(this.chkLinkRX1AF_CheckedChanged);
-            // 
-            // chkLinkMasterToRX0
-            // 
-            this.chkLinkRX0AF.AutoSize = true;
-            this.chkLinkRX0AF.Image = null;
-            this.chkLinkRX0AF.Location = new System.Drawing.Point(23, 47);
-            this.chkLinkRX0AF.Name = "chkLinkMasterToRX0";
-            this.chkLinkRX0AF.Size = new System.Drawing.Size(63, 17);
-            this.chkLinkRX0AF.TabIndex = 3;
-            this.chkLinkRX0AF.Text = "RX1 AF";
-            this.chkLinkRX0AF.UseVisualStyleBackColor = true;
-            this.chkLinkRX0AF.CheckedChanged += new System.EventHandler(this.chkLinkRX0AF_CheckedChanged);
             // 
             // chkDisableRearSpeakerJacksAudioAmplifier
             // 
@@ -47330,6 +47358,7 @@
             // tpAppearanceMeter
             // 
             this.tpAppearanceMeter.BackColor = System.Drawing.SystemColors.Control;
+            this.tpAppearanceMeter.Controls.Add(this.chkLegacyMeters);
             this.tpAppearanceMeter.Controls.Add(this.groupBoxTS14);
             this.tpAppearanceMeter.Controls.Add(this.labelTS2);
             this.tpAppearanceMeter.Controls.Add(this.clrbtnMeterDigBackground);
@@ -47344,6 +47373,21 @@
             this.tpAppearanceMeter.Size = new System.Drawing.Size(724, 410);
             this.tpAppearanceMeter.TabIndex = 2;
             this.tpAppearanceMeter.Text = "Meter";
+            // 
+            // chkLegacyMeters
+            // 
+            this.chkLegacyMeters.AutoSize = true;
+            this.chkLegacyMeters.Checked = true;
+            this.chkLegacyMeters.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkLegacyMeters.Image = null;
+            this.chkLegacyMeters.Location = new System.Drawing.Point(367, 23);
+            this.chkLegacyMeters.Name = "chkLegacyMeters";
+            this.chkLegacyMeters.Size = new System.Drawing.Size(113, 17);
+            this.chkLegacyMeters.TabIndex = 86;
+            this.chkLegacyMeters.Text = "Use legacy meters";
+            this.toolTip1.SetToolTip(this.chkLegacyMeters, "Show or hide the legacy meters");
+            this.chkLegacyMeters.UseVisualStyleBackColor = true;
+            this.chkLegacyMeters.CheckedChanged += new System.EventHandler(this.chkLegacyMeters_CheckedChanged);
             // 
             // groupBoxTS14
             // 
@@ -49743,13 +49787,14 @@
             // 
             // grpBoxSpaceBarPTT
             // 
+            this.grpBoxSpaceBarPTT.Controls.Add(this.radSpaceBarVFOBTX);
             this.grpBoxSpaceBarPTT.Controls.Add(this.radSpaceBarLastBtn);
             this.grpBoxSpaceBarPTT.Controls.Add(this.radSpaceBarMicMute);
             this.grpBoxSpaceBarPTT.Controls.Add(this.radSpaceBarVOX);
             this.grpBoxSpaceBarPTT.Controls.Add(this.radSpaceBarPTT);
             this.grpBoxSpaceBarPTT.Location = new System.Drawing.Point(525, 8);
             this.grpBoxSpaceBarPTT.Name = "grpBoxSpaceBarPTT";
-            this.grpBoxSpaceBarPTT.Size = new System.Drawing.Size(168, 112);
+            this.grpBoxSpaceBarPTT.Size = new System.Drawing.Size(168, 130);
             this.grpBoxSpaceBarPTT.TabIndex = 41;
             this.grpBoxSpaceBarPTT.TabStop = false;
             this.grpBoxSpaceBarPTT.Text = "SpaceBar Control";
@@ -49977,7 +50022,7 @@
             // 
             this.grpKeyboardOptions.Controls.Add(this.chkOptEnableKBShortcuts);
             this.grpKeyboardOptions.Controls.Add(this.chkOptQuickQSY);
-            this.grpKeyboardOptions.Location = new System.Drawing.Point(525, 139);
+            this.grpKeyboardOptions.Location = new System.Drawing.Point(525, 144);
             this.grpKeyboardOptions.Name = "grpKeyboardOptions";
             this.grpKeyboardOptions.Size = new System.Drawing.Size(168, 72);
             this.grpKeyboardOptions.TabIndex = 27;
@@ -55203,31 +55248,18 @@
             this.tmrCheckProfile.Interval = 1000;
             this.tmrCheckProfile.Tick += new System.EventHandler(this.tmrCheckProfile_Tick);
             // 
-            // groupBoxTS29
+            // radSpaceBarVFOBTX
             // 
-            this.groupBoxTS29.Controls.Add(this.chkLinkMaster);
-            this.groupBoxTS29.Controls.Add(this.chkLinkRX0AF);
-            this.groupBoxTS29.Controls.Add(this.chkLinkToRX2AF);
-            this.groupBoxTS29.Controls.Add(this.chkLinkRX1AF);
-            this.groupBoxTS29.Location = new System.Drawing.Point(19, 134);
-            this.groupBoxTS29.Name = "groupBoxTS29";
-            this.groupBoxTS29.Size = new System.Drawing.Size(200, 120);
-            this.groupBoxTS29.TabIndex = 6;
-            this.groupBoxTS29.TabStop = false;
-            this.groupBoxTS29.Text = "Linked AF Sliders";
-            this.toolTip1.SetToolTip(this.groupBoxTS29, "When one moves, the others move");
-            // 
-            // chkLinkMaster
-            // 
-            this.chkLinkMaster.AutoSize = true;
-            this.chkLinkMaster.Image = null;
-            this.chkLinkMaster.Location = new System.Drawing.Point(23, 24);
-            this.chkLinkMaster.Name = "chkLinkMaster";
-            this.chkLinkMaster.Size = new System.Drawing.Size(74, 17);
-            this.chkLinkMaster.TabIndex = 6;
-            this.chkLinkMaster.Text = "Master AF";
-            this.chkLinkMaster.UseVisualStyleBackColor = true;
-            this.chkLinkMaster.CheckedChanged += new System.EventHandler(this.chkLinkMaster_CheckedChanged);
+            this.radSpaceBarVFOBTX.AutoSize = true;
+            this.radSpaceBarVFOBTX.Image = null;
+            this.radSpaceBarVFOBTX.Location = new System.Drawing.Point(6, 103);
+            this.radSpaceBarVFOBTX.Name = "radSpaceBarVFOBTX";
+            this.radSpaceBarVFOBTX.Size = new System.Drawing.Size(115, 17);
+            this.radSpaceBarVFOBTX.TabIndex = 68;
+            this.radSpaceBarVFOBTX.Text = "VFOB_TX - Toggle";
+            this.toolTip1.SetToolTip(this.radSpaceBarVFOBTX, "SpaceBar Toggles To VFOB-TX");
+            this.radSpaceBarVFOBTX.UseVisualStyleBackColor = true;
+            this.radSpaceBarVFOBTX.CheckedChanged += new System.EventHandler(this.radSpaceBarVFOBTX_CheckedChanged);
             // 
             // Setup
             // 
@@ -55621,6 +55653,8 @@
             this.grpAudioDetails3.ResumeLayout(false);
             this.tpAudioOptions.ResumeLayout(false);
             this.tpAudioOptions.PerformLayout();
+            this.groupBoxTS29.ResumeLayout(false);
+            this.groupBoxTS29.PerformLayout();
             this.tpAdvancedAudio.ResumeLayout(false);
             this.tpAdvancedAudio.PerformLayout();
             this.grpVAC2ResamplerAdvanced.ResumeLayout(false);
@@ -56165,6 +56199,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.udDisplayLineWidth)).EndInit();
             this.grpDisplayPeakCursor.ResumeLayout(false);
             this.tpAppearanceMeter.ResumeLayout(false);
+            this.tpAppearanceMeter.PerformLayout();
             this.groupBoxTS14.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.tbSignalHistoryAlpha)).EndInit();
             this.grpMeterEdge.ResumeLayout(false);
@@ -56335,8 +56370,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS36)).EndInit();
             this.panelTS4.ResumeLayout(false);
             this.panelTS4.PerformLayout();
-            this.groupBoxTS29.ResumeLayout(false);
-            this.groupBoxTS29.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -59809,5 +59842,7 @@
         private CheckBoxTS chkLinkRX1AF;
         private GroupBoxTS groupBoxTS29;
         private CheckBoxTS chkLinkMaster;
+        private CheckBoxTS chkLegacyMeters;
+        private RadioButtonTS radSpaceBarVFOBTX;
     }
 }


### PR DESCRIPTION
1. Option in appearance->meter to turn off legacy meters 
2. VFOtx space bar toggle options in setup->keyboard
3. Fixes for noise floor fast attack time. Resizing can result in low frame rates which would cause problems for the fast attack. Now based on ms elapsed and not frame count
4. Moving MasterAF slider will unmute like the other sliders. Uses setting in setup-audio-options (rx1 only, this might need changing)