### PR TITLE
Quick split + Fade eye scale + TXprofile change report

### DIFF
--- a/Project Files/Source/Console/CAT/CATCommands.cs
+++ b/Project Files/Source/Console/CAT/CATCommands.cs
@@ -234,7 +234,7 @@ namespace Thetis
 
 		// Sets or reads VFO B to control tx
 		// another "happiness" command
-		public string FT(string s)
+		public string FT(string s, bool bFromCatDirect = false)
 		{
 			//			if(s.Length == parser.nSet)
 			//			{
@@ -254,7 +254,7 @@ namespace Thetis
 			//			}
 			//			else
 			//				return parser.Error1;
-			return ZZSP(s);
+			return ZZSP(s, bFromCatDirect);
 		}
 
 		// Sets or reads the DSP filter width
@@ -5740,10 +5740,19 @@ namespace Thetis
         }
 
 		// Sets or reads the VFO Split status
-		public string ZZSP(string s)
+		public string ZZSP(string s, bool bFromCatDirect = false)
 		{
 			if(s.Length == parser.nSet && (s == "0" || s == "1"))
 			{
+				if (bFromCatDirect && !console.IsSetupFormNull)
+				{
+					if (console.SetupForm.SplitFromCATorTCIcancelsQSPLIT)
+					{
+						if (console.SetupForm.QuickSplitEnabled)
+							console.SetupForm.QuickSplitEnabled = false;
+					}
+				}
+
 				if(s == "0")
 					console.VFOSplit = false;
 				else

--- a/Project Files/Source/Console/CAT/CATParser.cs
+++ b/Project Files/Source/Console/CAT/CATParser.cs
@@ -199,7 +199,7 @@ namespace Thetis
 					case "FS":
 						break;
 					case "FT":
-						rtncmd = cmdlist.FT(suffix);
+						rtncmd = cmdlist.FT(suffix, true);
 						break;
 					case "FW":
 						rtncmd = cmdlist.FW(suffix);
@@ -1168,7 +1168,7 @@ namespace Thetis
 					rtncmd = cmdlist.ZZSO(suffix);
 					break;
 				case "ZZSP":
-					rtncmd = cmdlist.ZZSP(suffix);
+					rtncmd = cmdlist.ZZSP(suffix, true);
 					break; 
 				case "ZZSQ":
 					rtncmd = cmdlist.ZZSQ(suffix);

--- a/Project Files/Source/Console/MeterManager.cs
+++ b/Project Files/Source/Console/MeterManager.cs
@@ -6859,7 +6859,7 @@ namespace Thetis
                                 case MeterType.MAGIC_EYE:
                                     {
                                         float fLargest = Math.Max(igs.EyeScale, igs.EyeBezelScale);
-
+                                        
                                         if (fLargest != ig.Size.Width)
                                         {
                                             ig.TopLeft = new PointF(0.5f - (fLargest / 2f), _fPadY - (_fHeight * 0.75f));
@@ -6922,8 +6922,8 @@ namespace Thetis
                                                 clsFadeCover fc = fcs.Value as clsFadeCover;
                                                 if (fc == null) continue;
 
-                                                fc.TopLeft = new PointF(0.5f - (igs.EyeScale / 2f), _fPadY - (_fHeight * 0.75f) + ((fLargest - igs.EyeScale) * 0.5f));
-                                                fc.Size = new SizeF(igs.EyeScale, igs.EyeScale);
+                                                fc.TopLeft = new PointF(0.5f - (fLargest / 2f), _fPadY - (_fHeight * 0.75f));
+                                                fc.Size = new SizeF(fLargest, fLargest);
                                             }
                                         }
                                     }

--- a/Project Files/Source/Console/TCIServer.cs
+++ b/Project Files/Source/Console/TCIServer.cs
@@ -1184,6 +1184,14 @@ namespace Thetis
 
 				if (bOK)
 				{
+					if (!console.ThreadSafeTCIAccessor.IsSetupFormNull)
+					{
+                        if (console.ThreadSafeTCIAccessor.SetupForm.SplitFromCATorTCIcancelsQSPLIT)
+                        {
+                            if (console.ThreadSafeTCIAccessor.SetupForm.QuickSplitEnabled)
+                                console.ThreadSafeTCIAccessor.SetupForm.QuickSplitEnabled = false;
+                        }
+                    }
 					if (rx == 0 || rx == 1)
 						if(console.ThreadSafeTCIAccessor.VFOSplit != bSplit)
 							console.ThreadSafeTCIAccessor.VFOSplit = bSplit;

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -42688,7 +42688,7 @@ namespace Thetis
             {
                 _ignoreQuickSplitSet = false;
                 return;
-            }
+            }            
 
             bool bRestore = false;
             if (!IsSetupFormNull && SetupForm.QuickSplitEnabled && !RX2Enabled)
@@ -42700,7 +42700,7 @@ namespace Thetis
                     {
                         _oldQuickSplitSettings = new Dictionary<string, object>();
 
-                        _oldQuickSplitSettings.Add("zoom", this.Zoom);
+                        _oldQuickSplitSettings.Add("zoom", Zoom);
                         _oldQuickSplitSettings.Add("multirx", chkEnableMultiRX.Checked);
                         _oldQuickSplitSettings.Add("txfl", chkShowTXFilter.Checked);
                         _oldQuickSplitSettings.Add("swapwheels", Midi2Cat.SwapVFOWheelsProperty);
@@ -42709,10 +42709,24 @@ namespace Thetis
                             _oldQuickSplitSettings.Add("VFOASubFreq", VFOASubFreq);
                         else
                             _oldQuickSplitSettings.Add("VFOBFreq", VFOBFreq);
+
+                        _oldQuickSplitSettings.Add("panmain", PanMainRX);
+                        _oldQuickSplitSettings.Add("pansub", PanSubRX);
                     }
                     //
 
                     double shift = SetupForm.QuickSplitShiftHz * 1e-6;
+
+                    //Note: qsplit has been disabled when rx2 in use, as it made no sense to use vfosuba
+                    //if (RX2Enabled)
+                    //{
+                    //    // must be sub vfo
+                    //    VFOASubFreq = VFOAFreq + shift;
+                    //}
+                    //else
+                    //{
+                    VFOBFreq = VFOAFreq + shift;
+                    //}
 
                     if (SetupForm.QuickSplitZoom && this.Zoom != 190)
                         this.Zoom = 190;
@@ -42726,16 +42740,22 @@ namespace Thetis
                     if (SetupForm.QuickSplitSwapVFOWheels && !Midi2Cat.SwapVFOWheelsProperty)
                         Midi2Cat.SwapVFOWheelsProperty = true;
 
-                    //Note: qsplit has been disabled when rx2 in use, as it made no sense to use vfosuba
-                    //if (RX2Enabled)
-                    //{
-                    //    // must be sub vfo
-                    //    VFOASubFreq = VFOAFreq + shift;
-                    //}
-                    //else
-                    //{
-                    VFOBFreq = VFOAFreq + shift;
-                    //}
+                    if (SetupForm.QuickSplitPanAudio)
+                    {
+                        // note this can be flipped if Swap turned on on main UI, resulting in double flip
+                        if (!SetupForm.QuickSplitPanAudioFlip)
+                        {
+                            // main in left, sub in right
+                            PanMainRX = 0;
+                            PanSubRX = 100;
+                        }
+                        else
+                        {
+                            // main in right, sub in left
+                            PanMainRX = 100;
+                            PanSubRX = 0;
+                        }
+                    }
                 }
                 else
                 {
@@ -42755,12 +42775,14 @@ namespace Thetis
                 //do we have old settings?
                 if (_oldQuickSplitSettings != null)
                 {
-                    if (_oldQuickSplitSettings.ContainsKey("zoom")) this.Zoom = (int)_oldQuickSplitSettings["zoom"];
+                    if (_oldQuickSplitSettings.ContainsKey("zoom")) Zoom = (int)_oldQuickSplitSettings["zoom"];
                     if (_oldQuickSplitSettings.ContainsKey("multirx")) chkEnableMultiRX.Checked = (bool)_oldQuickSplitSettings["multirx"];
                     if (_oldQuickSplitSettings.ContainsKey("txfl")) chkShowTXFilter.Checked = (bool)_oldQuickSplitSettings["txfl"];
                     if (_oldQuickSplitSettings.ContainsKey("swapwheels")) Midi2Cat.SwapVFOWheelsProperty = (bool)_oldQuickSplitSettings["swapwheels"];
                     if (_oldQuickSplitSettings.ContainsKey("VFOASubFreq")) VFOASubFreq = (double)_oldQuickSplitSettings["VFOASubFreq"];
                     if (_oldQuickSplitSettings.ContainsKey("VFOBFreq")) VFOBFreq = (double)_oldQuickSplitSettings["VFOBFreq"];
+                    if (_oldQuickSplitSettings.ContainsKey("panmain")) PanMainRX = (int)_oldQuickSplitSettings["panmain"];
+                    if (_oldQuickSplitSettings.ContainsKey("pansub")) PanSubRX = (int)_oldQuickSplitSettings["pansub"];
 
                     _oldQuickSplitSettings.Clear();
                     _oldQuickSplitSettings = null;

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -2414,6 +2414,7 @@ namespace Thetis
 
             //options2 tab
             chkQuickSplit_CheckedChanged(this, e);
+            chkQuickSplitPanAudio_CheckedChanged(this, e);
         }
 
         public string[] GetTXProfileStrings()
@@ -2458,12 +2459,40 @@ namespace Thetis
                 }
             }
         }
+        public static T ConvertFromDBVal<T>(object obj)
+        {
+            if (obj == null || obj == DBNull.Value)
+            {
+                return default(T); // returns the default value for the type
+            }
+            else
+            {
+                return (T)obj;
+            }
+        }
+        private bool isTXProfileSettingDifferent<T>(DataRow dr, string setting, T value, out string report)
+        {
+            if (dr.IsNull(setting))
+            {
+                report = "";
+                return false;
+            }
+
+            if (dr[setting] is T dbVal && !dbVal.Equals(value))
+            {
+                report = setting + " from [" + dbVal.ToString() + "] to [" + value.ToString() + "]" + Environment.NewLine;
+                return true;
+            }
+
+            report = "";
+            return false;
+        }
         private string getTXProfileChangeReport(DataRow drToCheck = null, bool bOnlyVac = false)
         {
             // duplicate of code from checkTXProfileChanged2
 
             string sReport = "";
-
+            string sReportOut = "";
             //bOnlyVac will only consider settings related to VAC
 
             DataRow dr;
@@ -2484,165 +2513,165 @@ namespace Thetis
 
             if (!bOnlyVac)
             {
-                if (DB.ConvertFromDBVal<int>(dr["FilterLow"]) != (int)udTXFilterLow.Value) sReport += "FilterLow" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["FilterHigh"]) != (int)udTXFilterHigh.Value) sReport += "FilterHigh" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["TXEQNumBands"]) != console.EQForm.NumBands) sReport += "TXEQNumBands" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["TXEQEnabled"]) != console.EQForm.TXEQEnabled) sReport += "TXEQEnabled" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<int>(dr, "FilterLow", (int)udTXFilterLow.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "FilterHigh", (int)udTXFilterHigh.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "TXEQNumBands", console.EQForm.NumBands, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "TXEQEnabled", console.EQForm.TXEQEnabled, out sReportOut)) sReport += sReportOut;
                 int[] eq = console.EQForm.TXEQ;
-                if (DB.ConvertFromDBVal<int>(dr["TXEQPreamp"]) != eq[0]) sReport += "TXEQPreamp" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<int>(dr, "TXEQPreamp", eq[0], out sReportOut)) sReport += sReportOut;
                 for (int i = 1; i < 11; i++)
-                    if (DB.ConvertFromDBVal<int>(dr["TXEQ" + i.ToString()]) != eq[i]) sReport += "TXEQ" + i.ToString() + Environment.NewLine;
+                    if (isTXProfileSettingDifferent<int>(dr, "TXEQ" + i.ToString(), eq[i], out sReportOut)) sReport += sReportOut;
                 for (int i = 11; i < 21; i++)
-                    if (DB.ConvertFromDBVal<int>(dr["TxEqFreq" + (i - 10).ToString()]) != eq[i]) sReport += "TxEqFreq" + (i - 10).ToString() + Environment.NewLine;
+                    if (isTXProfileSettingDifferent<int>(dr, "TxEqFreq" + (i - 10).ToString(), eq[i], out sReportOut)) sReport += sReportOut;
 
-                if (DB.ConvertFromDBVal<bool>(dr["DXOn"]) != console.DX) sReport += "DXOn" + Environment.NewLine;
-                //if (DB.ConvertFromDBVal<int>(dr["DXLevel"]) != console.DXLevel) sReport += "" + Environment.NewLine;  //MW0LGE_22b
-                if (DB.ConvertFromDBVal<bool>(dr["CompanderOn"]) != console.CPDR) sReport += "CompanderOn" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["CompanderLevel"]) != console.CPDRLevel) sReport += "CompanderLevel" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["MicGain"]) != console.Mic) sReport += "MicGain" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["FMMicGain"]) != console.FMMic) sReport += "FMMicGain" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["MicMute"]) != console.MicMute) sReport += "MicMute" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<bool>(dr, "DXOn", console.DX, out sReportOut)) sReport += sReportOut;
+                //if (isTXProfileSettingDifferent<int>(dr, "DXLevel", console.DXLevel, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "CompanderOn", console.CPDR, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "CompanderLevel", console.CPDRLevel, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "MicGain", console.Mic, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "FMMicGain", console.FMMic, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "MicMute", console.MicMute, out sReportOut)) sReport += sReportOut;
 
-                if (DB.ConvertFromDBVal<bool>(dr["Lev_On"]) != chkDSPLevelerEnabled.Checked) sReport += "Lev_On" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Lev_Slope"]) != (int)udDSPLevelerSlope.Value) sReport += "Lev_Slope" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Lev_MaxGain"]) != (int)udDSPLevelerThreshold.Value) sReport += "Lev_MaxGain" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Lev_Attack"]) != (int)udDSPLevelerAttack.Value) sReport += "Lev_Attack" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Lev_Decay"]) != (int)udDSPLevelerDecay.Value) sReport += "Lev_Decay" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Lev_Hang"]) != (int)udDSPLevelerHangTime.Value) sReport += "Lev_Hang" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Lev_HangThreshold"]) != tbDSPLevelerHangThreshold.Value) sReport += "Lev_HangThreshold" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<bool>(dr, "Lev_On", chkDSPLevelerEnabled.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Lev_Slope", (int)udDSPLevelerSlope.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Lev_MaxGain", (int)udDSPLevelerThreshold.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Lev_Attack", (int)udDSPLevelerAttack.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Lev_Decay", (int)udDSPLevelerDecay.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Lev_Hang", (int)udDSPLevelerHangTime.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Lev_HangThreshold", tbDSPLevelerHangThreshold.Value, out sReportOut)) sReport += sReportOut;
 
-                if (DB.ConvertFromDBVal<int>(dr["ALC_Slope"]) != (int)udDSPALCSlope.Value) sReport += "ALC_Slope" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["ALC_MaximumGain"]) != (int)udDSPALCMaximumGain.Value) sReport += "ALC_MaximumGain" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["ALC_Attack"]) != (int)udDSPALCAttack.Value) sReport += "ALC_Attack" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["ALC_Decay"]) != (int)udDSPALCDecay.Value) sReport += "ALC_Decay" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["ALC_Hang"]) != (int)udDSPALCHangTime.Value) sReport += "ALC_Hang" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["ALC_HangThreshold"]) != tbDSPALCHangThreshold.Value) sReport += "ALC_HangThreshold" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<int>(dr, "ALC_Slope", (int)udDSPALCSlope.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "ALC_MaximumGain", (int)udDSPALCMaximumGain.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "ALC_Attack", (int)udDSPALCAttack.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "ALC_Decay", (int)udDSPALCDecay.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "ALC_Hang", (int)udDSPALCHangTime.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "ALC_HangThreshold", tbDSPALCHangThreshold.Value, out sReportOut)) sReport += sReportOut;
 
-                //if (DB.ConvertFromDBVal<int>(dr["Power"]) != console.PWR) sReport += "" + Environment.NewLine;  //MW0LGE_21k9rc5 removed from tx profile as power is per band now
+                //if (isTXProfileSettingDifferent<int>(dr, "Power", console.PWR, out sReportOut)) sReport += sReportOut;  //MW0LGE_21k9rc5 removed from tx profile as power is per band now
 
-                if (DB.ConvertFromDBVal<bool>(dr["VOX_On"]) != chkVOXEnable.Checked) sReport += "VOX_On" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["Dexp_On"]) != chkDEXPEnable.Checked) sReport += "Dexp_On" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Dexp_Threshold"]) != (int)udDEXPThreshold.Value) sReport += "Dexp_Threshold" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Dexp_Attack"]) != (int)udDEXPAttack.Value) sReport += "Dexp_Attack" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["VOX_HangTime"]) != (int)udDEXPHold.Value) sReport += "VOX_HangTime" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Dexp_Release"]) != (int)udDEXPRelease.Value) sReport += "Dexp_Release" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<decimal>(dr["Dexp_Attenuate"]) != udDEXPExpansionRatio.Value) sReport += "Dexp_Attenuate" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<decimal>(dr["Dexp_Hysterisis"]) != udDEXPHysteresisRatio.Value) sReport += "Dexp_Hysterisis" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Dexp_Tau"]) != (int)udDEXPDetTau.Value) sReport += "Dexp_Tau" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["Dexp_SCF_On"]) != chkSCFEnable.Checked) sReport += "Dexp_SCF_On" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Dexp_SCF_Low"]) != (int)udSCFLowCut.Value) sReport += "Dexp_SCF_Low" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Dexp_SCF_High"]) != (int)udSCFHighCut.Value) sReport += "Dexp_SCF_High" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["Dexp_LookAhead_On"]) != chkDEXPLookAheadEnable.Checked) sReport += "Dexp_LookAhead_On" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["Dexp_LookAhead"]) != (int)udDEXPLookAhead.Value) sReport += "Dexp_LookAhead" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<bool>(dr, "VOX_On", chkVOXEnable.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "Dexp_On", chkDEXPEnable.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Dexp_Threshold", (int)udDEXPThreshold.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Dexp_Attack", (int)udDEXPAttack.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "VOX_HangTime", (int)udDEXPHold.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Dexp_Release", (int)udDEXPRelease.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<decimal>(dr, "Dexp_Attenuate", udDEXPExpansionRatio.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<decimal>(dr, "Dexp_Hysterisis", udDEXPHysteresisRatio.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Dexp_Tau", (int)udDEXPDetTau.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "Dexp_SCF_On", chkSCFEnable.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Dexp_SCF_Low", (int)udSCFLowCut.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Dexp_SCF_High", (int)udSCFHighCut.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "Dexp_LookAhead_On", chkDEXPLookAheadEnable.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "Dexp_LookAhead", (int)udDEXPLookAhead.Value, out sReportOut)) sReport += sReportOut;
 
-                //if (DB.ConvertFromDBVal<int>(dr["Tune_Power"]) != (int)udTXTunePower.Value) sReport += "" + Environment.NewLine; // [2.10.1.0] MW0LGE not used anymore
-                //if (DB.ConvertFromDBVal<string>(dr["Tune_Meter_Type"]) != (string)comboTXTUNMeter.Text) sReport += "" + Environment.NewLine; // [2.10.1.0] MW0LGE not used anymore
+                //if (isTXProfileSettingDifferent<int>(dr, "Tune_Power", (int)udTXTunePower.Value, out sReportOut)) sReport += sReportOut; // [2.10.1.0] MW0LGE not used anymore
+                //if (isTXProfileSettingDifferent<string>(dr, "Tune_Meter_Type", (string)comboTXTUNMeter.Text, out sReportOut)) sReport += sReportOut; // [2.10.1.0] MW0LGE not used anymore
 
-                if (DB.ConvertFromDBVal<int>(dr["TX_AF_Level"]) != console.TXAF) sReport += "TX_AF_Level" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<int>(dr, "TX_AF_Level", console.TXAF, out sReportOut)) sReport += sReportOut;
 
-                if (DB.ConvertFromDBVal<int>(dr["AM_Carrier_Level"]) != (int)udTXAMCarrierLevel.Value) sReport += "AM_Carrier_Level" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<int>(dr, "AM_Carrier_Level", (int)udTXAMCarrierLevel.Value, out sReportOut)) sReport += sReportOut;
 
-                if (DB.ConvertFromDBVal<bool>(dr["Show_TX_Filter"]) != (bool)console.ShowTXFilter) sReport += "Show_TX_Filter" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<bool>(dr, "Show_TX_Filter", (bool)console.ShowTXFilter, out sReportOut)) sReport += sReportOut;
             }
 
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_On"]) != (bool)chkAudioEnableVAC.Checked) sReport += "VAC1_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_Auto_On"]) != (bool)chkAudioVACAutoEnable.Checked) sReport += "VAC1_Auto_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC1_RX_GAIN"]) != (int)udAudioVACGainRX.Value) sReport += "VAC1_RX_GAIN" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC1_TX_GAIN"]) != (int)udAudioVACGainTX.Value) sReport += "VAC1_TX_GAIN" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_Stereo_On"]) != (bool)chkAudio2Stereo.Checked) sReport += "VAC1_Stereo_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<string>(dr["VAC1_Sample_Rate"]) != (string)comboAudioSampleRate2.Text) sReport += "VAC1_Sample_Rate" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<string>(dr["VAC1_Buffer_Size"]) != (string)comboAudioBuffer2.Text) sReport += "VAC1_Buffer_Size" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_IQ_Output"]) != (bool)chkAudioIQtoVAC.Checked) sReport += "VAC1_IQ_Output" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_IQ_Correct"]) != (bool)chkAudioCorrectIQ.Checked) sReport += "VAC1_IQ_Correct" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_PTT_OverRide"]) != (bool)chkVACAllowBypass.Checked) sReport += "VAC1_PTT_OverRide" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_Combine_Input_Channels"]) != (bool)chkVACCombine.Checked) sReport += "VAC1_Combine_Input_Channels" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_Latency_On"]) != (bool)chkAudioLatencyManual2.Checked) sReport += "VAC1_Latency_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC1_Latency_Duration"]) != (int)udAudioLatency2.Value) sReport += "VAC1_Latency_Duration" + Environment.NewLine;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_On", (bool)chkAudioEnableVAC.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_Auto_On", (bool)chkAudioVACAutoEnable.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC1_RX_GAIN", (int)udAudioVACGainRX.Value, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC1_TX_GAIN", (int)udAudioVACGainTX.Value, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_Stereo_On", (bool)chkAudio2Stereo.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC1_Sample_Rate", (string)comboAudioSampleRate2.Text, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC1_Buffer_Size", (string)comboAudioBuffer2.Text, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_IQ_Output", (bool)chkAudioIQtoVAC.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_IQ_Correct", (bool)chkAudioCorrectIQ.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_PTT_OverRide", (bool)chkVACAllowBypass.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_Combine_Input_Channels", (bool)chkVACCombine.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_Latency_On", (bool)chkAudioLatencyManual2.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC1_Latency_Duration", (int)udAudioLatency2.Value, out sReportOut)) sReport += sReportOut;
 
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_Latency_RBOut_On"]) != (bool)chkAudioLatencyManual2_Out.Checked) sReport += "VAC1_Latency_RBOut_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC1_Latency_RBOut_Duration"]) != (int)udAudioLatency2_Out.Value) sReport += "VAC1_Latency_RBOut_Duration" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_Latency_PAIn_On"]) != (bool)chkAudioLatencyPAInManual.Checked) sReport += "VAC1_Latency_PAIn_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC1_Latency_PAIn_Duration"]) != (int)udAudioLatencyPAIn.Value) sReport += "VAC1_Latency_PAIn_Duration" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC1_Latency_PAOut_On"]) != (bool)chkAudioLatencyPAOutManual.Checked) sReport += "VAC1_Latency_PAOut_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC1_Latency_PAOut_Duration"]) != (int)udAudioLatencyPAOut.Value) sReport += "VAC1_Latency_PAOut_Duration" + Environment.NewLine;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_Latency_RBOut_On", (bool)chkAudioLatencyManual2_Out.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC1_Latency_RBOut_Duration", (int)udAudioLatency2_Out.Value, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_Latency_PAIn_On", (bool)chkAudioLatencyPAInManual.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC1_Latency_PAIn_Duration", (int)udAudioLatencyPAIn.Value, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC1_Latency_PAOut_On", (bool)chkAudioLatencyPAOutManual.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC1_Latency_PAOut_Duration", (int)udAudioLatencyPAOut.Value, out sReportOut)) sReport += sReportOut;
 
-            if (DB.ConvertFromDBVal<string>(dr["VAC1_AudioDriver"]) != (string)comboAudioDriver2.Text) sReport += "VAC1_AudioDriver" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<string>(dr["VAC1_AudioInput"]) != (string)comboAudioInput2.Text) sReport += "VAC1_AudioInput" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<string>(dr["VAC1_AudioOutput"]) != (string)comboAudioOutput2.Text) sReport += "VAC1_AudioOutput" + Environment.NewLine;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC1_AudioDriver", (string)comboAudioDriver2.Text, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC1_AudioInput", (string)comboAudioInput2.Text, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC1_AudioOutput", (string)comboAudioOutput2.Text, out sReportOut)) sReport += sReportOut;
 
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_On"]) != (bool)chkVAC2Enable.Checked) sReport += "VAC2_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_Auto_On"]) != (bool)chkVAC2AutoEnable.Checked) sReport += "VAC2_Auto_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC2_RX_GAIN"]) != (int)udVAC2GainRX.Value) sReport += "VAC2_RX_GAIN" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC2_TX_GAIN"]) != (int)udVAC2GainTX.Value) sReport += "VAC2_TX_GAIN" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_Stereo_On"]) != (bool)chkAudioStereo3.Checked) sReport += "VAC2_Stereo_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<string>(dr["VAC2_Sample_Rate"]) != (string)comboAudioSampleRate3.Text) sReport += "VAC2_Sample_Rate" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<string>(dr["VAC2_Buffer_Size"]) != (string)comboAudioBuffer3.Text) sReport += "VAC2_Buffer_Size" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_IQ_Output"]) != (bool)chkVAC2DirectIQ.Checked) sReport += "VAC2_IQ_Output" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_IQ_Correct"]) != (bool)chkVAC2DirectIQCal.Checked) sReport += "VAC2_IQ_Correct" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_Combine_Input_Channels"]) != (bool)chkVAC2Combine.Checked) sReport += "VAC2_Combine_Input_Channels" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_Latency_On"]) != (bool)chkVAC2LatencyManual.Checked) sReport += "VAC2_Latency_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC2_Latency_Duration"]) != (int)udVAC2Latency.Value) sReport += "VAC2_Latency_Duration" + Environment.NewLine;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_On", (bool)chkVAC2Enable.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_Auto_On", (bool)chkVAC2AutoEnable.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC2_RX_GAIN", (int)udVAC2GainRX.Value, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC2_TX_GAIN", (int)udVAC2GainTX.Value, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_Stereo_On", (bool)chkAudioStereo3.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC2_Sample_Rate", (string)comboAudioSampleRate3.Text, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC2_Buffer_Size", (string)comboAudioBuffer3.Text, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_IQ_Output", (bool)chkVAC2DirectIQ.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_IQ_Correct", (bool)chkVAC2DirectIQCal.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_Combine_Input_Channels", (bool)chkVAC2Combine.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_Latency_On", (bool)chkVAC2LatencyManual.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC2_Latency_Duration", (int)udVAC2Latency.Value, out sReportOut)) sReport += sReportOut;
 
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_Latency_RBOut_On"]) != (bool)chkVAC2LatencyOutManual.Checked) sReport += "VAC2_Latency_RBOut_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC2_Latency_RBOut_Duration"]) != (int)udVAC2LatencyOut.Value) sReport += "VAC2_Latency_RBOut_Duration" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_Latency_PAIn_On"]) != (bool)chkVAC2LatencyPAInManual.Checked) sReport += "VAC2_Latency_PAIn_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC2_Latency_PAIn_Duration"]) != (int)udVAC2LatencyPAIn.Value) sReport += "VAC2_Latency_PAIn_Duration" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<bool>(dr["VAC2_Latency_PAOut_On"]) != (bool)chkVAC2LatencyPAOutManual.Checked) sReport += "VAC2_Latency_PAOut_On" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<int>(dr["VAC2_Latency_PAOut_Duration"]) != (int)udVAC2LatencyPAOut.Value) sReport += "VAC2_Latency_PAOut_Duration" + Environment.NewLine;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_Latency_RBOut_On", (bool)chkVAC2LatencyOutManual.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC2_Latency_RBOut_Duration", (int)udVAC2LatencyOut.Value, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_Latency_PAIn_On", (bool)chkVAC2LatencyPAInManual.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC2_Latency_PAIn_Duration", (int)udVAC2LatencyPAIn.Value, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<bool>(dr, "VAC2_Latency_PAOut_On", (bool)chkVAC2LatencyPAOutManual.Checked, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<int>(dr, "VAC2_Latency_PAOut_Duration", (int)udVAC2LatencyPAOut.Value, out sReportOut)) sReport += sReportOut;
 
-            if (DB.ConvertFromDBVal<string>(dr["VAC2_AudioDriver"]) != (string)comboAudioDriver3.Text) sReport += "VAC2_AudioDriver" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<string>(dr["VAC2_AudioInput"]) != (string)comboAudioInput3.Text) sReport += "VAC2_AudioInput" + Environment.NewLine;
-            if (DB.ConvertFromDBVal<string>(dr["VAC2_AudioOutput"]) != (string)comboAudioOutput3.Text) sReport += "VAC2_AudioOutput" + Environment.NewLine;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC2_AudioDriver", (string)comboAudioDriver3.Text, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC2_AudioInput", (string)comboAudioInput3.Text, out sReportOut)) sReport += sReportOut;
+            if (isTXProfileSettingDifferent<string>(dr, "VAC2_AudioOutput", (string)comboAudioOutput3.Text, out sReportOut)) sReport += sReportOut;
 
             if (!bOnlyVac)
             {
-                if (DB.ConvertFromDBVal<string>(dr["Phone_RX_DSP_Buffer"]) != (string)comboDSPPhoneRXBuf.Text) sReport += "Phone_RX_DSP_Buffer" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Phone_TX_DSP_Buffer"]) != (string)comboDSPPhoneTXBuf.Text) sReport += "Phone_TX_DSP_Buffer" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["FM_RX_DSP_Buffer"]) != (string)comboDSPFMRXBuf.Text) sReport += "FM_RX_DSP_Buffer" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["FM_TX_DSP_Buffer"]) != (string)comboDSPFMTXBuf.Text) sReport += "FM_TX_DSP_Buffer" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Digi_RX_DSP_Buffer"]) != (string)comboDSPDigRXBuf.Text) sReport += "Digi_RX_DSP_Buffer" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Digi_TX_DSP_Buffer"]) != (string)comboDSPDigTXBuf.Text) sReport += "Digi_TX_DSP_Buffer" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["CW_RX_DSP_Buffer"]) != (string)comboDSPCWRXBuf.Text) sReport += "CW_RX_DSP_Buffer" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<string>(dr, "Phone_RX_DSP_Buffer", (string)comboDSPPhoneRXBuf.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Phone_TX_DSP_Buffer", (string)comboDSPPhoneTXBuf.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "FM_RX_DSP_Buffer", (string)comboDSPFMRXBuf.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "FM_TX_DSP_Buffer", (string)comboDSPFMTXBuf.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Digi_RX_DSP_Buffer", (string)comboDSPDigRXBuf.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Digi_TX_DSP_Buffer", (string)comboDSPDigTXBuf.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "CW_RX_DSP_Buffer", (string)comboDSPCWRXBuf.Text, out sReportOut)) sReport += sReportOut;
 
-                if (DB.ConvertFromDBVal<string>(dr["Phone_RX_DSP_Filter_Size"]) != (string)comboDSPPhoneRXFiltSize.Text) sReport += "Phone_RX_DSP_Filter_Size" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Phone_TX_DSP_Filter_Size"]) != (string)comboDSPPhoneTXFiltSize.Text) sReport += "Phone_TX_DSP_Filter_Size" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["FM_RX_DSP_Filter_Size"]) != (string)comboDSPFMRXFiltSize.Text) sReport += "FM_RX_DSP_Filter_Size" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["FM_TX_DSP_Filter_Size"]) != (string)comboDSPFMTXFiltSize.Text) sReport += "FM_TX_DSP_Filter_Size" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Digi_RX_DSP_Filter_Size"]) != (string)comboDSPDigRXFiltSize.Text) sReport += "Digi_RX_DSP_Filter_Size" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Digi_TX_DSP_Filter_Size"]) != (string)comboDSPDigTXFiltSize.Text) sReport += "Digi_TX_DSP_Filter_Size" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["CW_RX_DSP_Filter_Size"]) != (string)comboDSPCWRXFiltSize.Text) sReport += "CW_RX_DSP_Filter_Size" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<string>(dr, "Phone_RX_DSP_Filter_Size", (string)comboDSPPhoneRXFiltSize.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Phone_TX_DSP_Filter_Size", (string)comboDSPPhoneTXFiltSize.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "FM_RX_DSP_Filter_Size", (string)comboDSPFMRXFiltSize.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "FM_TX_DSP_Filter_Size", (string)comboDSPFMTXFiltSize.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Digi_RX_DSP_Filter_Size", (string)comboDSPDigRXFiltSize.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Digi_TX_DSP_Filter_Size", (string)comboDSPDigTXFiltSize.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "CW_RX_DSP_Filter_Size", (string)comboDSPCWRXFiltSize.Text, out sReportOut)) sReport += sReportOut;
 
-                if (DB.ConvertFromDBVal<string>(dr["Phone_RX_DSP_Filter_Type"]) != (string)comboDSPPhoneRXFiltType.Text) sReport += "Phone_RX_DSP_Filter_Type" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Phone_TX_DSP_Filter_Type"]) != (string)comboDSPPhoneTXFiltType.Text) sReport += "Phone_TX_DSP_Filter_Type" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["FM_RX_DSP_Filter_Type"]) != (string)comboDSPFMRXFiltType.Text) sReport += "FM_RX_DSP_Filter_Type" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["FM_TX_DSP_Filter_Type"]) != (string)comboDSPFMTXFiltType.Text) sReport += "FM_TX_DSP_Filter_Type" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Digi_RX_DSP_Filter_Type"]) != (string)comboDSPDigRXFiltType.Text) sReport += "Digi_RX_DSP_Filter_Type" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["Digi_TX_DSP_Filter_Type"]) != (string)comboDSPDigTXFiltType.Text) sReport += "Digi_TX_DSP_Filter_Type" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<string>(dr["CW_RX_DSP_Filter_Type"]) != (string)comboDSPCWRXFiltType.Text) sReport += "CW_RX_DSP_Filter_Type" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<string>(dr, "Phone_RX_DSP_Filter_Type", (string)comboDSPPhoneRXFiltType.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Phone_TX_DSP_Filter_Type", (string)comboDSPPhoneTXFiltType.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "FM_RX_DSP_Filter_Type", (string)comboDSPFMRXFiltType.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "FM_TX_DSP_Filter_Type", (string)comboDSPFMTXFiltType.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Digi_RX_DSP_Filter_Type", (string)comboDSPDigRXFiltType.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "Digi_TX_DSP_Filter_Type", (string)comboDSPDigTXFiltType.Text, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<string>(dr, "CW_RX_DSP_Filter_Type", (string)comboDSPCWRXFiltType.Text, out sReportOut)) sReport += sReportOut;
 
-                if (DB.ConvertFromDBVal<bool>(dr["Mic_Input_On"]) != (bool)radMicIn.Checked) sReport += "Mic_Input_On" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["Mic_Input_Boost"]) != (bool)chk20dbMicBoost.Checked) sReport += "Mic_Input_Boost" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["Line_Input_On"]) != (bool)radLineIn.Checked) sReport += "Line_Input_On" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<decimal>(dr["Line_Input_Level"]) != udLineInBoost.Value) sReport += "Line_Input_Level" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["CESSB_On"]) != chkDSPCESSB.Checked) sReport += "CESSB_On" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["Pure_Signal_Enabled"]) != console.PureSignalEnabled) sReport += "Pure_Signal_Enabled" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<bool>(dr, "Mic_Input_On", (bool)radMicIn.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "Mic_Input_Boost", (bool)chk20dbMicBoost.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "Line_Input_On", (bool)radLineIn.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<decimal>(dr, "Line_Input_Level", udLineInBoost.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "CESSB_On", chkDSPCESSB.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "Pure_Signal_Enabled", console.PureSignalEnabled, out sReportOut)) sReport += sReportOut;
 
                 //CFC
-                if (DB.ConvertFromDBVal<bool>(dr["CFCEnabled"]) != chkCFCEnable.Checked) sReport += "CFCEnabled" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["CFCPostEqEnabled"]) != chkCFCPeqEnable.Checked) sReport += "CFCPostEqEnabled" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<bool>(dr["CFCPhaseRotatorEnabled"]) != chkPHROTEnable.Checked) sReport += "CFCPhaseRotatorEnabled" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["CFCPhaseRotatorFreq"]) != (int)udPhRotFreq.Value) sReport += "CFCPhaseRotatorFreq" + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["CFCPhaseRotatorStages"]) != (int)udPHROTStages.Value) sReport += "CFCPhaseRotatorStages" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<bool>(dr, "CFCEnabled", chkCFCEnable.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "CFCPostEqEnabled", chkCFCPeqEnable.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<bool>(dr, "CFCPhaseRotatorEnabled", chkPHROTEnable.Checked, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "CFCPhaseRotatorFreq", (int)udPhRotFreq.Value, out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "CFCPhaseRotatorStages", (int)udPHROTStages.Value, out sReportOut)) sReport += sReportOut;
                 int[] cfceq = CFCCOMPEQ;
-                if (DB.ConvertFromDBVal<int>(dr["CFCPreComp"]) != cfceq[0]) sReport += "CFCPreComp" + Environment.NewLine;
+                if (isTXProfileSettingDifferent<int>(dr, "CFCPreComp", cfceq[0], out sReportOut)) sReport += sReportOut;
                 for (int i = 1; i < 11; i++)
-                    if (DB.ConvertFromDBVal<int>(dr["CFCPreComp" + (i - 1).ToString()]) != cfceq[i]) sReport += "CFCPreComp" + (i - 1).ToString() + Environment.NewLine;
-                if (DB.ConvertFromDBVal<int>(dr["CFCPostEqGain"]) != cfceq[11]) sReport += "CFCPostEqGain" + Environment.NewLine;
+                    if (isTXProfileSettingDifferent<int>(dr, "CFCPreComp" + (i - 1).ToString(), cfceq[i], out sReportOut)) sReport += sReportOut;
+                if (isTXProfileSettingDifferent<int>(dr, "CFCPostEqGain", cfceq[11], out sReportOut)) sReport += sReportOut;
                 for (int i = 12; i < 22; i++)
-                    if (DB.ConvertFromDBVal<int>(dr["CFCPostEqGain" + (i - 12).ToString()]) != cfceq[i]) sReport += "CFCPostEqGain" + (i - 12).ToString() + Environment.NewLine;
+                    if (isTXProfileSettingDifferent<int>(dr, "CFCPostEqGain" + (i - 12).ToString(), cfceq[i], out sReportOut)) sReport += sReportOut;
                 for (int i = 22; i < 32; i++)
-                    if (DB.ConvertFromDBVal<int>(dr["CFCEqFreq" + (i - 22).ToString()]) != cfceq[i]) sReport += "CFCEqFreq" + (i - 22).ToString() + Environment.NewLine;
-            }
+                    if (isTXProfileSettingDifferent<int>(dr, "CFCEqFreq" + (i - 22).ToString(), cfceq[i], out sReportOut)) sReport += sReportOut;
+            }      
 
             return sReport;
         }
@@ -27235,6 +27264,18 @@ namespace Thetis
         {
             get { return chkQuickSplitSwapVFOWheels.Checked; }
         }
+        public bool QuickSplitPanAudio
+        {
+            get { return chkQuickSplitPanAudio.Checked; }
+        }
+        public bool QuickSplitPanAudioFlip
+        {
+            get { return chkQuickSplitPanAudio.Checked && chkQuickSplitPanAudioFlip.Checked; }
+        }
+        public bool SplitFromCATorTCIcancelsQSPLIT
+        {
+            get { return chkCancelQSplitOnCatTCIsplit.Checked; }
+        }
         private void chkQuickSplit_CheckedChanged(object sender, EventArgs e)
         {
             if (initializing) return;
@@ -27317,6 +27358,13 @@ namespace Thetis
             }
             else
                 txtboxTXProfileChangedReport.Visible = false;
+        }
+
+        private void chkQuickSplitPanAudio_CheckedChanged(object sender, EventArgs e)
+        {
+            if (initializing) return;
+
+            chkQuickSplitPanAudioFlip.Enabled = chkQuickSplitPanAudio.Checked;
         }
     }
 

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -336,8 +336,12 @@
             this.lblOptClickTuneDIGU = new System.Windows.Forms.LabelTS();
             this.udOptClickTuneOffsetDIGU = new System.Windows.Forms.NumericUpDownTS();
             this.tpOptions2 = new System.Windows.Forms.TabPage();
+            this.chkCancelQSplitOnCatTCIsplit = new System.Windows.Forms.CheckBoxTS();
             this.chkQuickSplit = new System.Windows.Forms.CheckBoxTS();
             this.grpQuickSplit = new System.Windows.Forms.GroupBoxTS();
+            this.chkQuickSplitPanAudioFlip = new System.Windows.Forms.CheckBoxTS();
+            this.chkQuickSplitPanAudio = new System.Windows.Forms.CheckBoxTS();
+            this.labelQuickSplitInfo = new System.Windows.Forms.LabelTS();
             this.btnQuickSplitUp5 = new System.Windows.Forms.ButtonTS();
             this.btnQuickSplitDown5 = new System.Windows.Forms.ButtonTS();
             this.chkQuickSplitSwapVFOWheels = new System.Windows.Forms.CheckBoxTS();
@@ -8882,6 +8886,7 @@
             // tpOptions2
             // 
             this.tpOptions2.BackColor = System.Drawing.SystemColors.Control;
+            this.tpOptions2.Controls.Add(this.chkCancelQSplitOnCatTCIsplit);
             this.tpOptions2.Controls.Add(this.chkQuickSplit);
             this.tpOptions2.Controls.Add(this.grpQuickSplit);
             this.tpOptions2.Controls.Add(this.groupBoxTS26);
@@ -8895,21 +8900,36 @@
             this.tpOptions2.TabIndex = 1;
             this.tpOptions2.Text = "Options-2";
             // 
+            // chkCancelQSplitOnCatTCIsplit
+            // 
+            this.chkCancelQSplitOnCatTCIsplit.AutoSize = true;
+            this.chkCancelQSplitOnCatTCIsplit.Image = null;
+            this.chkCancelQSplitOnCatTCIsplit.Location = new System.Drawing.Point(446, 171);
+            this.chkCancelQSplitOnCatTCIsplit.Name = "chkCancelQSplitOnCatTCIsplit";
+            this.chkCancelQSplitOnCatTCIsplit.Size = new System.Drawing.Size(254, 17);
+            this.chkCancelQSplitOnCatTCIsplit.TabIndex = 38;
+            this.chkCancelQSplitOnCatTCIsplit.Text = "Cancel Quick Split on CAT or TCI split command";
+            this.toolTip1.SetToolTip(this.chkCancelQSplitOnCatTCIsplit, "Quick Split is disabled if a split message is received from cat or tci");
+            this.chkCancelQSplitOnCatTCIsplit.UseVisualStyleBackColor = true;
+            // 
             // chkQuickSplit
             // 
             this.chkQuickSplit.AutoSize = true;
             this.chkQuickSplit.Image = null;
             this.chkQuickSplit.Location = new System.Drawing.Point(446, 194);
             this.chkQuickSplit.Name = "chkQuickSplit";
-            this.chkQuickSplit.Size = new System.Drawing.Size(189, 17);
+            this.chkQuickSplit.Size = new System.Drawing.Size(183, 17);
             this.chkQuickSplit.TabIndex = 37;
-            this.chkQuickSplit.Text = "Quick Split   (rx on vfoa tx on vfob)";
+            this.chkQuickSplit.Text = "Quick Split (rx on vfoa tx on vfob)";
             this.toolTip1.SetToolTip(this.chkQuickSplit, "Enable quick split for the split button on rx1");
             this.chkQuickSplit.UseVisualStyleBackColor = true;
             this.chkQuickSplit.CheckedChanged += new System.EventHandler(this.chkQuickSplit_CheckedChanged);
             // 
             // grpQuickSplit
             // 
+            this.grpQuickSplit.Controls.Add(this.chkQuickSplitPanAudioFlip);
+            this.grpQuickSplit.Controls.Add(this.chkQuickSplitPanAudio);
+            this.grpQuickSplit.Controls.Add(this.labelQuickSplitInfo);
             this.grpQuickSplit.Controls.Add(this.btnQuickSplitUp5);
             this.grpQuickSplit.Controls.Add(this.btnQuickSplitDown5);
             this.grpQuickSplit.Controls.Add(this.chkQuickSplitSwapVFOWheels);
@@ -8920,14 +8940,49 @@
             this.grpQuickSplit.Controls.Add(this.nudQuickSplitShift);
             this.grpQuickSplit.Location = new System.Drawing.Point(438, 194);
             this.grpQuickSplit.Name = "grpQuickSplit";
-            this.grpQuickSplit.Size = new System.Drawing.Size(257, 156);
+            this.grpQuickSplit.Size = new System.Drawing.Size(257, 184);
             this.grpQuickSplit.TabIndex = 36;
             this.grpQuickSplit.TabStop = false;
+            // 
+            // chkQuickSplitPanAudioFlip
+            // 
+            this.chkQuickSplitPanAudioFlip.AutoSize = true;
+            this.chkQuickSplitPanAudioFlip.Enabled = false;
+            this.chkQuickSplitPanAudioFlip.Image = null;
+            this.chkQuickSplitPanAudioFlip.Location = new System.Drawing.Point(39, 161);
+            this.chkQuickSplitPanAudioFlip.Name = "chkQuickSplitPanAudioFlip";
+            this.chkQuickSplitPanAudioFlip.Size = new System.Drawing.Size(42, 17);
+            this.chkQuickSplitPanAudioFlip.TabIndex = 47;
+            this.chkQuickSplitPanAudioFlip.Text = "Flip";
+            this.chkQuickSplitPanAudioFlip.UseVisualStyleBackColor = true;
+            // 
+            // chkQuickSplitPanAudio
+            // 
+            this.chkQuickSplitPanAudio.AutoSize = true;
+            this.chkQuickSplitPanAudio.Image = null;
+            this.chkQuickSplitPanAudio.Location = new System.Drawing.Point(19, 142);
+            this.chkQuickSplitPanAudio.Name = "chkQuickSplitPanAudio";
+            this.chkQuickSplitPanAudio.Size = new System.Drawing.Size(74, 17);
+            this.chkQuickSplitPanAudio.TabIndex = 46;
+            this.chkQuickSplitPanAudio.Text = "Pan audio";
+            this.toolTip1.SetToolTip(this.chkQuickSplitPanAudio, "vfoA in left ear, vfoB in right ear. Flipped if flip is on");
+            this.chkQuickSplitPanAudio.UseVisualStyleBackColor = true;
+            this.chkQuickSplitPanAudio.CheckedChanged += new System.EventHandler(this.chkQuickSplitPanAudio_CheckedChanged);
+            // 
+            // labelQuickSplitInfo
+            // 
+            this.labelQuickSplitInfo.Image = null;
+            this.labelQuickSplitInfo.Location = new System.Drawing.Point(123, 139);
+            this.labelQuickSplitInfo.Name = "labelQuickSplitInfo";
+            this.labelQuickSplitInfo.Size = new System.Drawing.Size(125, 39);
+            this.labelQuickSplitInfo.TabIndex = 45;
+            this.labelQuickSplitInfo.Text = "note: options are\r\napplied when QSPLT\r\nis changed to on state";
+            this.labelQuickSplitInfo.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // btnQuickSplitUp5
             // 
             this.btnQuickSplitUp5.Image = null;
-            this.btnQuickSplitUp5.Location = new System.Drawing.Point(185, 30);
+            this.btnQuickSplitUp5.Location = new System.Drawing.Point(185, 21);
             this.btnQuickSplitUp5.Name = "btnQuickSplitUp5";
             this.btnQuickSplitUp5.Selectable = true;
             this.btnQuickSplitUp5.Size = new System.Drawing.Size(42, 23);
@@ -8939,7 +8994,7 @@
             // btnQuickSplitDown5
             // 
             this.btnQuickSplitDown5.Image = null;
-            this.btnQuickSplitDown5.Location = new System.Drawing.Point(138, 30);
+            this.btnQuickSplitDown5.Location = new System.Drawing.Point(138, 21);
             this.btnQuickSplitDown5.Name = "btnQuickSplitDown5";
             this.btnQuickSplitDown5.Selectable = true;
             this.btnQuickSplitDown5.Size = new System.Drawing.Size(42, 23);
@@ -8952,7 +9007,7 @@
             // 
             this.chkQuickSplitSwapVFOWheels.AutoSize = true;
             this.chkQuickSplitSwapVFOWheels.Image = null;
-            this.chkQuickSplitSwapVFOWheels.Location = new System.Drawing.Point(19, 128);
+            this.chkQuickSplitSwapVFOWheels.Location = new System.Drawing.Point(19, 119);
             this.chkQuickSplitSwapVFOWheels.Name = "chkQuickSplitSwapVFOWheels";
             this.chkQuickSplitSwapVFOWheels.Size = new System.Drawing.Size(143, 17);
             this.chkQuickSplitSwapVFOWheels.TabIndex = 43;
@@ -8964,7 +9019,7 @@
             // 
             this.chkQuickSplitFL.AutoSize = true;
             this.chkQuickSplitFL.Image = null;
-            this.chkQuickSplitFL.Location = new System.Drawing.Point(19, 105);
+            this.chkQuickSplitFL.Location = new System.Drawing.Point(19, 96);
             this.chkQuickSplitFL.Name = "chkQuickSplitFL";
             this.chkQuickSplitFL.Size = new System.Drawing.Size(143, 17);
             this.chkQuickSplitFL.TabIndex = 42;
@@ -8976,7 +9031,7 @@
             // 
             this.chkQuickSplitMultiRX.AutoSize = true;
             this.chkQuickSplitMultiRX.Image = null;
-            this.chkQuickSplitMultiRX.Location = new System.Drawing.Point(19, 82);
+            this.chkQuickSplitMultiRX.Location = new System.Drawing.Point(19, 73);
             this.chkQuickSplitMultiRX.Name = "chkQuickSplitMultiRX";
             this.chkQuickSplitMultiRX.Size = new System.Drawing.Size(99, 17);
             this.chkQuickSplitMultiRX.TabIndex = 41;
@@ -8988,7 +9043,7 @@
             // 
             this.chkQuickSplitZoom.AutoSize = true;
             this.chkQuickSplitZoom.Image = null;
-            this.chkQuickSplitZoom.Location = new System.Drawing.Point(19, 59);
+            this.chkQuickSplitZoom.Location = new System.Drawing.Point(19, 50);
             this.chkQuickSplitZoom.Name = "chkQuickSplitZoom";
             this.chkQuickSplitZoom.Size = new System.Drawing.Size(65, 17);
             this.chkQuickSplitZoom.TabIndex = 40;
@@ -9000,7 +9055,7 @@
             // 
             this.labelTS182.AutoSize = true;
             this.labelTS182.Image = null;
-            this.labelTS182.Location = new System.Drawing.Point(89, 35);
+            this.labelTS182.Location = new System.Drawing.Point(89, 26);
             this.labelTS182.Name = "labelTS182";
             this.labelTS182.Size = new System.Drawing.Size(29, 13);
             this.labelTS182.TabIndex = 39;
@@ -9013,7 +9068,7 @@
             0,
             0,
             0});
-            this.nudQuickSplitShift.Location = new System.Drawing.Point(19, 33);
+            this.nudQuickSplitShift.Location = new System.Drawing.Point(19, 24);
             this.nudQuickSplitShift.Maximum = new decimal(new int[] {
             15000,
             0,
@@ -9049,7 +9104,7 @@
             this.groupBoxTS26.Controls.Add(this.nudNFsensitivity);
             this.groupBoxTS26.Location = new System.Drawing.Point(438, 13);
             this.groupBoxTS26.Name = "groupBoxTS26";
-            this.groupBoxTS26.Size = new System.Drawing.Size(257, 175);
+            this.groupBoxTS26.Size = new System.Drawing.Size(257, 146);
             this.groupBoxTS26.TabIndex = 35;
             this.groupBoxTS26.TabStop = false;
             this.groupBoxTS26.Text = "Noise Floor";
@@ -9058,7 +9113,7 @@
             // 
             this.chkNewNoiseFloorMethod.AutoSize = true;
             this.chkNewNoiseFloorMethod.Image = null;
-            this.chkNewNoiseFloorMethod.Location = new System.Drawing.Point(21, 143);
+            this.chkNewNoiseFloorMethod.Location = new System.Drawing.Point(21, 124);
             this.chkNewNoiseFloorMethod.Name = "chkNewNoiseFloorMethod";
             this.chkNewNoiseFloorMethod.Size = new System.Drawing.Size(137, 17);
             this.chkNewNoiseFloorMethod.TabIndex = 17;
@@ -9070,7 +9125,7 @@
             // btnResetNFShift
             // 
             this.btnResetNFShift.Image = null;
-            this.btnResetNFShift.Location = new System.Drawing.Point(164, 46);
+            this.btnResetNFShift.Location = new System.Drawing.Point(164, 43);
             this.btnResetNFShift.Name = "btnResetNFShift";
             this.btnResetNFShift.Selectable = true;
             this.btnResetNFShift.Size = new System.Drawing.Size(47, 23);
@@ -9083,7 +9138,7 @@
             // labelTS160
             // 
             this.labelTS160.Image = null;
-            this.labelTS160.Location = new System.Drawing.Point(13, 92);
+            this.labelTS160.Location = new System.Drawing.Point(13, 82);
             this.labelTS160.Name = "labelTS160";
             this.labelTS160.Size = new System.Drawing.Size(145, 35);
             this.labelTS160.TabIndex = 15;
@@ -9093,7 +9148,7 @@
             // btnRX2PBsnr
             // 
             this.btnRX2PBsnr.Image = null;
-            this.btnRX2PBsnr.Location = new System.Drawing.Point(164, 107);
+            this.btnRX2PBsnr.Location = new System.Drawing.Point(164, 97);
             this.btnRX2PBsnr.Name = "btnRX2PBsnr";
             this.btnRX2PBsnr.Selectable = true;
             this.btnRX2PBsnr.Size = new System.Drawing.Size(47, 23);
@@ -9106,7 +9161,7 @@
             // btnRX1PBsnr
             // 
             this.btnRX1PBsnr.Image = null;
-            this.btnRX1PBsnr.Location = new System.Drawing.Point(164, 78);
+            this.btnRX1PBsnr.Location = new System.Drawing.Point(164, 73);
             this.btnRX1PBsnr.Name = "btnRX1PBsnr";
             this.btnRX1PBsnr.Selectable = true;
             this.btnRX1PBsnr.Size = new System.Drawing.Size(47, 23);
@@ -9120,7 +9175,7 @@
             // 
             this.labelTS157.AutoSize = true;
             this.labelTS157.Image = null;
-            this.labelTS157.Location = new System.Drawing.Point(123, 49);
+            this.labelTS157.Location = new System.Drawing.Point(123, 46);
             this.labelTS157.Name = "labelTS157";
             this.labelTS157.Size = new System.Drawing.Size(28, 13);
             this.labelTS157.TabIndex = 12;
@@ -9130,7 +9185,7 @@
             // 
             this.labelTS156.AutoSize = true;
             this.labelTS156.Image = null;
-            this.labelTS156.Location = new System.Drawing.Point(38, 49);
+            this.labelTS156.Location = new System.Drawing.Point(38, 46);
             this.labelTS156.Name = "labelTS156";
             this.labelTS156.Size = new System.Drawing.Size(26, 13);
             this.labelTS156.TabIndex = 11;
@@ -9145,7 +9200,7 @@
             0,
             0,
             65536});
-            this.nudNFshift.Location = new System.Drawing.Point(70, 47);
+            this.nudNFshift.Location = new System.Drawing.Point(70, 44);
             this.nudNFshift.Maximum = new decimal(new int[] {
             12,
             0,
@@ -55267,12 +55322,12 @@
             // txtboxTXProfileChangedReport
             // 
             this.txtboxTXProfileChangedReport.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(192)))), ((int)(((byte)(128)))));
-            this.txtboxTXProfileChangedReport.Location = new System.Drawing.Point(327, 478);
+            this.txtboxTXProfileChangedReport.Location = new System.Drawing.Point(234, 494);
             this.txtboxTXProfileChangedReport.Multiline = true;
             this.txtboxTXProfileChangedReport.Name = "txtboxTXProfileChangedReport";
             this.txtboxTXProfileChangedReport.ReadOnly = true;
             this.txtboxTXProfileChangedReport.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtboxTXProfileChangedReport.Size = new System.Drawing.Size(180, 128);
+            this.txtboxTXProfileChangedReport.Size = new System.Drawing.Size(326, 128);
             this.txtboxTXProfileChangedReport.TabIndex = 25;
             this.txtboxTXProfileChangedReport.Text = "used to report tx profile changes if you click on oragne box";
             this.txtboxTXProfileChangedReport.Visible = false;
@@ -59863,5 +59918,9 @@
         private CheckBoxTS chkLegacyMeters;
         private RadioButtonTS radSpaceBarVFOBTX;
         private TextBoxTS txtboxTXProfileChangedReport;
+        private LabelTS labelQuickSplitInfo;
+        private CheckBoxTS chkQuickSplitPanAudioFlip;
+        private CheckBoxTS chkQuickSplitPanAudio;
+        private CheckBoxTS chkCancelQSplitOnCatTCIsplit;
     }
 }

--- a/Project Files/Source/Console/titlebar.cs
+++ b/Project Files/Source/Console/titlebar.cs
@@ -34,7 +34,7 @@ namespace Thetis
 {
     class TitleBar
     {
-        public const string BUILD_NAME = "pre-release2";
+        public const string BUILD_NAME = "pre-release3";
         public const string BUILD_DATE = "(10/04/23)<FW>"; //MW0LGE_21g <FW> gets replaced in BasicTitle (console.cs) with firmware version
 
         public static string GetString()


### PR DESCRIPTION
1. quick split audio pan
2. quick split disable when cat/tci split message option 
3. fix for when magic eye bezel and eye are different scales
4. added report for tx profile changes, click on the orange box
