### PR TITLE
No title bar meter container, improvements to auto CW swap, meter item disable

### DIFF
--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -20339,118 +20339,118 @@ namespace Thetis
             }
         }
 
-        private DSPMode saved_cw_auto_switch_dsp_mode = DSPMode.FIRST;
-        public void SetConsoleMox(bool b)
-        {
-            if (disable_ptt && b) return;
-            DSPMode tx_mode = radio.GetDSPTX(0).CurrentDSPMode;
+        //private DSPMode saved_cw_auto_switch_dsp_mode = DSPMode.FIRST;
+        //public void SetConsoleMox(bool b)
+        //{
+        //    if (disable_ptt && b) return;
+        //    DSPMode tx_mode = radio.GetDSPTX(0).CurrentDSPMode;
 
-            if (cw_auto_mode_switch)
-            {
-                CWAutoSwitchMode(b, tx_mode);
-            }
-            else
-            {
-                switch (tx_mode)
-                {
-                    case DSPMode.CWL:
-                    case DSPMode.CWU:
-                        MOX = b;
-                        break;
-                }
-            }
-        }
+        //    if (cw_auto_mode_switch)
+        //    {
+        //        CWAutoSwitchMode(b, tx_mode);
+        //    }
+        //    else
+        //    {
+        //        switch (tx_mode)
+        //        {
+        //            case DSPMode.CWL:
+        //            case DSPMode.CWU:
+        //                MOX = b;
+        //                break;
+        //        }
+        //    }
+        //}
 
-        private void CWAutoSwitchMode(bool b, DSPMode tx_mode)
-        {
-            if (b)
-            {
-                if (saved_cw_auto_switch_dsp_mode != tx_mode)
-                    saved_cw_auto_switch_dsp_mode = tx_mode;
+        //private void CWAutoSwitchMode(bool b, DSPMode tx_mode)
+        //{
+        //    if (b)
+        //    {
+        //        if (saved_cw_auto_switch_dsp_mode != tx_mode)
+        //            saved_cw_auto_switch_dsp_mode = tx_mode;
 
-                switch (tx_mode)
-                {
-                    case DSPMode.CWL:
-                    case DSPMode.CWU:
-                        break; // do nothing
-                    case DSPMode.LSB:
-                    case DSPMode.DIGL:
-                        if (rx2_enabled && chkVFOBTX.Checked)
-                            Invoke(new MethodInvoker(radRX2ModeCWL.Select)); // switch RX2 to CWL mode
-                        else Invoke(new MethodInvoker(radModeCWL.Select)); // switch RX1 to CWL mode
-                        break;
-                    case DSPMode.USB:
-                    case DSPMode.DIGU:
-                    case DSPMode.AM:
-                    case DSPMode.SAM:
-                    case DSPMode.FM:
-                    case DSPMode.DSB:
-                    case DSPMode.DRM:
-                        if (rx2_enabled && chkVFOBTX.Checked)
-                            Invoke(new MethodInvoker(radRX2ModeCWU.Select)); // switch RX2 to CWU mode    
-                        else Invoke(new MethodInvoker(radModeCWU.Select)); // switch RX1 to CWU mode
-                        break;
-                }
+        //        switch (tx_mode)
+        //        {
+        //            case DSPMode.CWL:
+        //            case DSPMode.CWU:
+        //                break; // do nothing
+        //            case DSPMode.LSB:
+        //            case DSPMode.DIGL:
+        //                if (rx2_enabled && chkVFOBTX.Checked)
+        //                    Invoke(new MethodInvoker(radRX2ModeCWL.Select)); // switch RX2 to CWL mode
+        //                else Invoke(new MethodInvoker(radModeCWL.Select)); // switch RX1 to CWL mode
+        //                break;
+        //            case DSPMode.USB:
+        //            case DSPMode.DIGU:
+        //            case DSPMode.AM:
+        //            case DSPMode.SAM:
+        //            case DSPMode.FM:
+        //            case DSPMode.DSB:
+        //            case DSPMode.DRM:
+        //                if (rx2_enabled && chkVFOBTX.Checked)
+        //                    Invoke(new MethodInvoker(radRX2ModeCWU.Select)); // switch RX2 to CWU mode    
+        //                else Invoke(new MethodInvoker(radModeCWU.Select)); // switch RX1 to CWU mode
+        //                break;
+        //        }
 
-                MOX = true;
-            }
-            else
-            {
-                MOX = false;
-                switch (saved_cw_auto_switch_dsp_mode)
-                {
-                    case DSPMode.CWL:
-                    case DSPMode.CWU:
-                        break; // do nothing
-                    default:
-                        RadioButtonTS rad = null;
-                        bool rx2 = (rx2_enabled && chkVFOBTX.Checked);
-                        switch (saved_cw_auto_switch_dsp_mode)
-                        {
-                            case DSPMode.LSB:
-                                if (rx2) rad = radRX2ModeLSB;
-                                else rad = radModeLSB;
-                                break;
-                            case DSPMode.USB:
-                                if (rx2) rad = radRX2ModeUSB;
-                                else rad = radModeUSB;
-                                break;
-                            case DSPMode.DSB:
-                                if (rx2) rad = radRX2ModeDSB;
-                                else rad = radModeDSB;
-                                break;
-                            case DSPMode.FM:
-                                if (rx2) rad = radRX2ModeFMN;
-                                else rad = radModeFMN;
-                                break;
-                            case DSPMode.AM:
-                                if (rx2) rad = radRX2ModeAM;
-                                else rad = radModeAM;
-                                break;
-                            case DSPMode.SAM:
-                                if (rx2) rad = radRX2ModeSAM;
-                                else rad = radModeSAM;
-                                break;
-                            case DSPMode.DIGL:
-                                if (rx2) rad = radRX2ModeDIGL;
-                                else rad = radModeDIGL;
-                                break;
-                            case DSPMode.DIGU:
-                                if (rx2) rad = radRX2ModeDIGU;
-                                else rad = radModeDIGU;
-                                break;
-                            case DSPMode.DRM:
-                                if (rx2) rad = radRX2ModeDRM;
-                                else rad = radModeDRM;
-                                break;
-                        }
+        //        MOX = true;
+        //    }
+        //    else
+        //    {
+        //        MOX = false;
+        //        switch (saved_cw_auto_switch_dsp_mode)
+        //        {
+        //            case DSPMode.CWL:
+        //            case DSPMode.CWU:
+        //                break; // do nothing
+        //            default:
+        //                RadioButtonTS rad = null;
+        //                bool rx2 = (rx2_enabled && chkVFOBTX.Checked);
+        //                switch (saved_cw_auto_switch_dsp_mode)
+        //                {
+        //                    case DSPMode.LSB:
+        //                        if (rx2) rad = radRX2ModeLSB;
+        //                        else rad = radModeLSB;
+        //                        break;
+        //                    case DSPMode.USB:
+        //                        if (rx2) rad = radRX2ModeUSB;
+        //                        else rad = radModeUSB;
+        //                        break;
+        //                    case DSPMode.DSB:
+        //                        if (rx2) rad = radRX2ModeDSB;
+        //                        else rad = radModeDSB;
+        //                        break;
+        //                    case DSPMode.FM:
+        //                        if (rx2) rad = radRX2ModeFMN;
+        //                        else rad = radModeFMN;
+        //                        break;
+        //                    case DSPMode.AM:
+        //                        if (rx2) rad = radRX2ModeAM;
+        //                        else rad = radModeAM;
+        //                        break;
+        //                    case DSPMode.SAM:
+        //                        if (rx2) rad = radRX2ModeSAM;
+        //                        else rad = radModeSAM;
+        //                        break;
+        //                    case DSPMode.DIGL:
+        //                        if (rx2) rad = radRX2ModeDIGL;
+        //                        else rad = radModeDIGL;
+        //                        break;
+        //                    case DSPMode.DIGU:
+        //                        if (rx2) rad = radRX2ModeDIGU;
+        //                        else rad = radModeDIGU;
+        //                        break;
+        //                    case DSPMode.DRM:
+        //                        if (rx2) rad = radRX2ModeDRM;
+        //                        else rad = radModeDRM;
+        //                        break;
+        //                }
 
-                        if (rad != null)
-                            Invoke(new MethodInvoker(rad.Select));
-                        break;
-                }
-            }
-        }
+        //                if (rad != null)
+        //                    Invoke(new MethodInvoker(rad.Select));
+        //                break;
+        //        }
+        //    }
+        //}
 
         // Sets or reads the PS-A button
         public bool PSA
@@ -28257,29 +28257,97 @@ namespace Thetis
             }
         }
 
+        private void cwAutoModeTick(object o)
+        {
+            bool bRx2 = (bool)o;
+
+            if(_old_cw_auto_mode != DSPMode.FIRST)
+            {
+                if (bRx2)
+                {
+                    if(InvokeRequired)
+                        Invoke(new Action(() => { RX2DSPMode = _old_cw_auto_mode; }));
+                    else
+                        RX2DSPMode = _old_cw_auto_mode;
+                }
+                else
+                {
+                    if (InvokeRequired)
+                        Invoke(new Action(() => { RX1DSPMode = _old_cw_auto_mode; }));
+                    else
+                        RX1DSPMode = _old_cw_auto_mode;
+                }
+            }
+        }
+        private DSPMode _old_cw_auto_mode = DSPMode.FIRST;
+        private bool _return_from_cw_auto_mode_switch = false;
+        private int _return_from_cw_auto_mode_switch_ms = 2000;
+        private System.Threading.Timer _cwAutoModeTick = null;
         private bool fw_dot = false;
+        public bool AutoModeSwitchCWReturn
+        {
+            get { return _return_from_cw_auto_mode_switch; }
+            set { _return_from_cw_auto_mode_switch = value; }
+        }
+        public int AutoModeSwitchCWReturnMs
+        {
+            get { return _return_from_cw_auto_mode_switch_ms; }
+            set { _return_from_cw_auto_mode_switch_ms = value; }
+        }        
         public bool FWDot
         {
             get { return fw_dot; }
             set
             {
+                //[2.10.1.0] MW0LGE modified to implement #70
+                bool bTxOnRx2 = RX2Enabled && VFOBTX;
+                DSPMode currentMode = bTxOnRx2 ? RX2DSPMode : RX1DSPMode;
+                bool bInCW = currentMode == DSPMode.CWL || currentMode == DSPMode.CWU;
+
                 fw_dot = value;
 
                 if (value && cw_auto_mode_switch)
                 {
-                    switch (rx1_dsp_mode)
+                    if (!bInCW)
                     {
-                        case DSPMode.CWL:
-                        case DSPMode.CWU:
-                            break;
-                        case DSPMode.LSB:
-                        case DSPMode.DIGL:
-                            RX1DSPMode = DSPMode.CWL;
-                            break;
-                        default:
-                            RX1DSPMode = DSPMode.CWU;
-                            break;
+                        if (_return_from_cw_auto_mode_switch && _old_cw_auto_mode != currentMode)
+                            _old_cw_auto_mode = currentMode;
+
+                        switch (currentMode)
+                        {
+                            case DSPMode.CWL:
+                            case DSPMode.CWU:
+                                break;
+                            case DSPMode.LSB:
+                            case DSPMode.DIGL:
+                                if (bTxOnRx2)
+                                    RX2DSPMode = DSPMode.CWL;
+                                else
+                                    RX1DSPMode = DSPMode.CWL;
+                                break;
+                            default:
+                                if (bTxOnRx2)
+                                    RX2DSPMode = DSPMode.CWU;
+                                else
+                                    RX1DSPMode = DSPMode.CWU;
+                                break;
+                        }
                     }
+
+                    // return after some time, start timer
+                    if (_return_from_cw_auto_mode_switch)
+                    {
+                        if(_cwAutoModeTick != null)
+                        {
+                            _cwAutoModeTick.Change(Timeout.Infinite, Timeout.Infinite);
+                            _cwAutoModeTick.Dispose();
+                            _cwAutoModeTick = null;
+                        }
+
+                        _cwAutoModeTick = new System.Threading.Timer(cwAutoModeTick, bTxOnRx2, _return_from_cw_auto_mode_switch_ms, Timeout.Infinite);
+                    }
+                    else
+                        _old_cw_auto_mode = DSPMode.FIRST;
                 }
             }
         }
@@ -34342,11 +34410,18 @@ namespace Thetis
             if (EQForm != null) EQForm.RXEQEnabled = chkRXEQ.Checked;
         }
 
+        private bool _oldTXEQ = false; // it is false in frm design
         private void chkTXEQ_CheckedChanged(object sender, System.EventArgs e)
         {
             if (chkTXEQ.Checked) chkTXEQ.BackColor = button_selected_color;
             else chkTXEQ.BackColor = SystemColors.Control;
             if (EQForm != null) EQForm.TXEQEnabled = chkTXEQ.Checked;
+
+            if (_oldTXEQ != chkTXEQ.Checked)
+            {
+                EQChangedHandlers?.Invoke(_oldTXEQ, chkTXEQ.Checked);
+                _oldTXEQ = chkTXEQ.Checked;
+            }
         }
 
         #endregion
@@ -43386,6 +43461,7 @@ namespace Thetis
             set { txosctrl = value; }
         }
 
+        private bool _oldCompandState = false; // initial state to match frm design
         private void chkCPDR_CheckedChanged(object sender, System.EventArgs e)
         {
             if (chkCPDR.Checked)
@@ -43416,6 +43492,11 @@ namespace Thetis
             cat_cmpd_status = Convert.ToInt32(chkCPDR.Checked);
             AndromedaIndicatorCheck(EIndicatorActions.eINCompanderEnabled, false, chkCPDR.Checked);
 
+            if(_oldCompandState != chkCPDR.Checked)
+            {
+                CompandChangedHandlers?.Invoke(_oldCompandState, chkCPDR.Checked);
+                _oldCompandState = chkCPDR.Checked;
+            }
         }
 
         private void ptbCPDR_Scroll(object sender, System.EventArgs e)
@@ -53165,6 +53246,11 @@ namespace Thetis
         public delegate void MONChanged(bool oldState, bool newState);
         public delegate void MONVolumeChanged(int oldVolume, int newVolume);
 
+        public delegate void EQChanged(bool oldState, bool newState);
+        public delegate void LevelerChanged(bool oldState, bool newState);
+        public delegate void CFCChanged(bool oldState, bool newState);
+        public delegate void CompandChanged(bool oldState, bool newState);
+
         public BandPreChange BandPreChangeHandlers; // when someone clicks a band button, before a change is made
         public BandNoChange BandNoChangeHandlers;
         public BandChanged BandChangeHandlers;
@@ -53212,6 +53298,11 @@ namespace Thetis
         public MuteChanged MuteChangedHandlers;
         public MONChanged MONChangedHandlers;
         public MONVolumeChanged MONVolumeChangedHandlers;
+
+        public EQChanged EQChangedHandlers;
+        public LevelerChanged LevelerChangedHandlers;
+        public CFCChanged CFCChangedHandlers;
+        public CompandChanged CompandChangedHandlers;
 
         private bool m_bIgnoreFrequencyDupes = false;               // if an update is to be made, but the frequency is already in the filter, ignore it
         private bool m_bHideBandstackWindowOnSelect = false;        // hide the window if an entry is selected

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -2096,6 +2096,9 @@ namespace Thetis
             chkCFCDisplayAutoScale_CheckedChanged(this, e);
             udCFCPicDBPerLine_ValueChanged(this, e);
 
+            chkCWAutoSwitchMode_CheckedChanged(this, e);
+            chkAutoModeSwitchCWReturn_CheckedChanged(this, e);
+
             //AGC
             udDSPAGCFixedGaindB_ValueChanged(this, e);
             udDSPAGCMaxGaindB_ValueChanged(this, e);
@@ -10156,12 +10159,19 @@ namespace Thetis
             console.radio.GetDSPTX(0).TXLevelerDecay = (int)udDSPLevelerDecay.Value;
         }
 
+        private bool _oldLevelerState = true; //it is true in frm design
         private void chkDSPLevelerEnabled_CheckedChanged(object sender, System.EventArgs e)
         {
             console.radio.GetDSPTX(0).TXLevelerOn = chkDSPLevelerEnabled.Checked;
 
             //
             console.SetupInfoBarButton(ucInfoBar.ActionTypes.Leveler, chkDSPLevelerEnabled.Checked);
+
+            if(_oldLevelerState != chkDSPLevelerEnabled.Checked)
+            {
+                console.LevelerChangedHandlers?.Invoke(_oldLevelerState, chkDSPLevelerEnabled.Checked);
+                _oldLevelerState = chkDSPLevelerEnabled.Checked;
+            }
         }
 
         #endregion
@@ -13794,6 +13804,7 @@ namespace Thetis
         private void chkCWAutoSwitchMode_CheckedChanged(object sender, System.EventArgs e)
         {
             console.CWAutoModeSwitch = chkCWAutoSwitchMode.Checked;
+            setEnabledAutoModeSwitchCWReturn(chkCWAutoSwitchMode.Checked);
         }
 
         private void clrbtnGenBackground_Changed(object sender, System.EventArgs e)//k6jca 1/13/08
@@ -19696,6 +19707,7 @@ namespace Thetis
             console.EnableXVTRHF = chkEnableXVTRHF.Checked;
         }
 
+        private bool _oldCFCState = false; // is false in frm design
         private void chkCFCEnable_CheckedChanged(object sender, EventArgs e)
         {
             int run;
@@ -19705,6 +19717,12 @@ namespace Thetis
 
             //
             console.SetupInfoBarButton(ucInfoBar.ActionTypes.CFC, chkCFCEnable.Checked);
+
+            if(_oldCFCState != chkCFCEnable.Checked)
+            {
+                console.CFCChangedHandlers?.Invoke(_oldCFCState, chkCFCEnable.Checked);
+                _oldCFCState = chkCFCEnable.Checked;
+            }
         }
 
         private void setCFCProfile(object sender, EventArgs e)
@@ -26042,6 +26060,7 @@ namespace Thetis
             comboContainerSelect.Enabled = bEnableControls;
             clrbtnContainerBackground.Enabled = bEnableControls;
             chkContainerBorder.Enabled = bEnableControls;
+            chkContainerNoTitle.Enabled = bEnableControls;
             lblMMContainerBackground.Enabled = bEnableControls;
             lstMetersAvailable.Enabled = bEnableControls;
             lstMetersInUse.Enabled = bEnableControls;
@@ -27395,6 +27414,34 @@ namespace Thetis
             if (initializing) return;
 
             Display.JoinBandEdges = chkJoinBandEdges.Checked;
+        }
+
+        private void chkContainerNoTitle_CheckedChanged(object sender, EventArgs e)
+        {
+            clsContainerComboboxItem cci = (clsContainerComboboxItem)comboContainerSelect.SelectedItem;
+            if (cci != null)
+            {
+                MeterManager.NoTitleWhenPinned(cci.ID, chkContainerNoTitle.Checked);
+            }
+        }
+
+        private void chkAutoModeSwitchCWReturn_CheckedChanged(object sender, EventArgs e)
+        {
+            nudAutoModeSwitchCWReturn.Enabled = chkAutoModeSwitchCWReturn.Checked;
+            lblAutoModeSwitchCWms.Enabled = chkAutoModeSwitchCWReturn.Checked;
+
+            console.AutoModeSwitchCWReturn = chkAutoModeSwitchCWReturn.Checked;
+            nudAutoModeSwitchCWReturn_ValueChanged(this, e);
+        }
+        private void setEnabledAutoModeSwitchCWReturn(bool bEnable)
+        {
+            chkAutoModeSwitchCWReturn.Enabled = bEnable;
+            nudAutoModeSwitchCWReturn.Enabled = chkAutoModeSwitchCWReturn.Checked;
+            lblAutoModeSwitchCWms.Enabled = chkAutoModeSwitchCWReturn.Checked;
+        }
+        private void nudAutoModeSwitchCWReturn_ValueChanged(object sender, EventArgs e)
+        {
+            console.AutoModeSwitchCWReturnMs = (int)nudAutoModeSwitchCWReturn.Value;
         }
     }
 

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -2958,6 +2958,7 @@
             this.comboMeterType = new System.Windows.Forms.ComboBoxTS();
             this.tpAppearanceMeter2 = new System.Windows.Forms.TabPage();
             this.grpMultiMeterHolder = new System.Windows.Forms.GroupBoxTS();
+            this.chkContainerNoTitle = new System.Windows.Forms.CheckBoxTS();
             this.btnMeterCopySettings = new System.Windows.Forms.ButtonTS();
             this.btnMeterPasteSettings = new System.Windows.Forms.ButtonTS();
             this.grpMeterItemVfoDisplaySettings = new System.Windows.Forms.GroupBoxTS();
@@ -3478,6 +3479,9 @@
             this.radioButtonTS6 = new System.Windows.Forms.RadioButtonTS();
             this.tmrCheckProfile = new System.Windows.Forms.Timer(this.components);
             this.txtboxTXProfileChangedReport = new System.Windows.Forms.TextBoxTS();
+            this.chkAutoModeSwitchCWReturn = new System.Windows.Forms.CheckBoxTS();
+            this.nudAutoModeSwitchCWReturn = new System.Windows.Forms.NumericUpDownTS();
+            this.lblAutoModeSwitchCWms = new System.Windows.Forms.LabelTS();
             tpAlexAntCtrl = new System.Windows.Forms.TabPage();
             numericUpDownTS3 = new System.Windows.Forms.NumericUpDownTS();
             numericUpDownTS4 = new System.Windows.Forms.NumericUpDownTS();
@@ -4397,6 +4401,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS35)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS36)).BeginInit();
             this.panelTS4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutoModeSwitchCWReturn)).BeginInit();
             this.SuspendLayout();
             // 
             // tpAlexAntCtrl
@@ -34459,6 +34464,9 @@
             // 
             // grpDSPKeyerOptions
             // 
+            this.grpDSPKeyerOptions.Controls.Add(this.lblAutoModeSwitchCWms);
+            this.grpDSPKeyerOptions.Controls.Add(this.nudAutoModeSwitchCWReturn);
+            this.grpDSPKeyerOptions.Controls.Add(this.chkAutoModeSwitchCWReturn);
             this.grpDSPKeyerOptions.Controls.Add(this.udCWKeyerWeight);
             this.grpDSPKeyerOptions.Controls.Add(this.chkDSPKeyerSidetone);
             this.grpDSPKeyerOptions.Controls.Add(this.chkStrictCharSpacing);
@@ -34469,7 +34477,7 @@
             this.grpDSPKeyerOptions.Controls.Add(this.chkCWAutoSwitchMode);
             this.grpDSPKeyerOptions.Location = new System.Drawing.Point(296, 8);
             this.grpDSPKeyerOptions.Name = "grpDSPKeyerOptions";
-            this.grpDSPKeyerOptions.Size = new System.Drawing.Size(142, 204);
+            this.grpDSPKeyerOptions.Size = new System.Drawing.Size(188, 223);
             this.grpDSPKeyerOptions.TabIndex = 37;
             this.grpDSPKeyerOptions.TabStop = false;
             this.grpDSPKeyerOptions.Text = "Options";
@@ -34481,7 +34489,7 @@
             0,
             0,
             0});
-            this.udCWKeyerWeight.Location = new System.Drawing.Point(72, 178);
+            this.udCWKeyerWeight.Location = new System.Drawing.Point(72, 187);
             this.udCWKeyerWeight.Maximum = new decimal(new int[] {
             66,
             0,
@@ -34523,7 +34531,7 @@
             // 
             this.chkStrictCharSpacing.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.chkStrictCharSpacing.Image = null;
-            this.chkStrictCharSpacing.Location = new System.Drawing.Point(16, 140);
+            this.chkStrictCharSpacing.Location = new System.Drawing.Point(16, 160);
             this.chkStrictCharSpacing.Name = "chkStrictCharSpacing";
             this.chkStrictCharSpacing.Size = new System.Drawing.Size(113, 16);
             this.chkStrictCharSpacing.TabIndex = 46;
@@ -34560,7 +34568,7 @@
             // lblCWWeight
             // 
             this.lblCWWeight.Image = null;
-            this.lblCWWeight.Location = new System.Drawing.Point(13, 178);
+            this.lblCWWeight.Location = new System.Drawing.Point(13, 187);
             this.lblCWWeight.Name = "lblCWWeight";
             this.lblCWWeight.Size = new System.Drawing.Size(48, 16);
             this.lblCWWeight.TabIndex = 39;
@@ -47789,6 +47797,7 @@
             // 
             // grpMultiMeterHolder
             // 
+            this.grpMultiMeterHolder.Controls.Add(this.chkContainerNoTitle);
             this.grpMultiMeterHolder.Controls.Add(this.btnMeterCopySettings);
             this.grpMultiMeterHolder.Controls.Add(this.btnMeterPasteSettings);
             this.grpMultiMeterHolder.Controls.Add(this.grpMeterItemVfoDisplaySettings);
@@ -47813,6 +47822,20 @@
             this.grpMultiMeterHolder.Size = new System.Drawing.Size(703, 385);
             this.grpMultiMeterHolder.TabIndex = 86;
             this.grpMultiMeterHolder.TabStop = false;
+            // 
+            // chkContainerNoTitle
+            // 
+            this.chkContainerNoTitle.AutoSize = true;
+            this.chkContainerNoTitle.Image = null;
+            this.chkContainerNoTitle.Location = new System.Drawing.Point(23, 100);
+            this.chkContainerNoTitle.Name = "chkContainerNoTitle";
+            this.chkContainerNoTitle.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.chkContainerNoTitle.Size = new System.Drawing.Size(123, 17);
+            this.chkContainerNoTitle.TabIndex = 104;
+            this.chkContainerNoTitle.Text = "No title when pinned";
+            this.toolTip1.SetToolTip(this.chkContainerNoTitle, "Prevents the display of the mouse over title bar when pinned");
+            this.chkContainerNoTitle.UseVisualStyleBackColor = true;
+            this.chkContainerNoTitle.CheckedChanged += new System.EventHandler(this.chkContainerNoTitle_CheckedChanged);
             // 
             // btnMeterCopySettings
             // 
@@ -48297,7 +48320,7 @@
             // 
             this.chkContainerBorder.AutoSize = true;
             this.chkContainerBorder.Image = null;
-            this.chkContainerBorder.Location = new System.Drawing.Point(100, 83);
+            this.chkContainerBorder.Location = new System.Drawing.Point(89, 77);
             this.chkContainerBorder.Name = "chkContainerBorder";
             this.chkContainerBorder.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
             this.chkContainerBorder.Size = new System.Drawing.Size(57, 17);
@@ -49189,7 +49212,7 @@
             // 
             this.chkContainerHighlight.AutoSize = true;
             this.chkContainerHighlight.Image = null;
-            this.chkContainerHighlight.Location = new System.Drawing.Point(90, 60);
+            this.chkContainerHighlight.Location = new System.Drawing.Point(79, 54);
             this.chkContainerHighlight.Name = "chkContainerHighlight";
             this.chkContainerHighlight.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
             this.chkContainerHighlight.Size = new System.Drawing.Size(67, 17);
@@ -55347,6 +55370,58 @@
             this.txtboxTXProfileChangedReport.Text = "used to report tx profile changes if you click on oragne box";
             this.txtboxTXProfileChangedReport.Visible = false;
             // 
+            // chkAutoModeSwitchCWReturn
+            // 
+            this.chkAutoModeSwitchCWReturn.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chkAutoModeSwitchCWReturn.Image = null;
+            this.chkAutoModeSwitchCWReturn.Location = new System.Drawing.Point(29, 138);
+            this.chkAutoModeSwitchCWReturn.Name = "chkAutoModeSwitchCWReturn";
+            this.chkAutoModeSwitchCWReturn.Size = new System.Drawing.Size(63, 16);
+            this.chkAutoModeSwitchCWReturn.TabIndex = 48;
+            this.chkAutoModeSwitchCWReturn.Text = "Return";
+            this.toolTip1.SetToolTip(this.chkAutoModeSwitchCWReturn, "Return to previous mode");
+            this.chkAutoModeSwitchCWReturn.CheckedChanged += new System.EventHandler(this.chkAutoModeSwitchCWReturn_CheckedChanged);
+            // 
+            // nudAutoModeSwitchCWReturn
+            // 
+            this.nudAutoModeSwitchCWReturn.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.nudAutoModeSwitchCWReturn.Location = new System.Drawing.Point(98, 137);
+            this.nudAutoModeSwitchCWReturn.Maximum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            0});
+            this.nudAutoModeSwitchCWReturn.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nudAutoModeSwitchCWReturn.Name = "nudAutoModeSwitchCWReturn";
+            this.nudAutoModeSwitchCWReturn.Size = new System.Drawing.Size(56, 20);
+            this.nudAutoModeSwitchCWReturn.TabIndex = 49;
+            this.nudAutoModeSwitchCWReturn.TinyStep = false;
+            this.toolTip1.SetToolTip(this.nudAutoModeSwitchCWReturn, "Selects the preferred CW tone frequency.");
+            this.nudAutoModeSwitchCWReturn.Value = new decimal(new int[] {
+            2000,
+            0,
+            0,
+            0});
+            this.nudAutoModeSwitchCWReturn.ValueChanged += new System.EventHandler(this.nudAutoModeSwitchCWReturn_ValueChanged);
+            // 
+            // lblAutoModeSwitchCWms
+            // 
+            this.lblAutoModeSwitchCWms.AutoSize = true;
+            this.lblAutoModeSwitchCWms.Image = null;
+            this.lblAutoModeSwitchCWms.Location = new System.Drawing.Point(160, 141);
+            this.lblAutoModeSwitchCWms.Name = "lblAutoModeSwitchCWms";
+            this.lblAutoModeSwitchCWms.Size = new System.Drawing.Size(20, 13);
+            this.lblAutoModeSwitchCWms.TabIndex = 50;
+            this.lblAutoModeSwitchCWms.Text = "ms";
+            // 
             // Setup
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -55916,6 +55991,7 @@
             this.grpDSPCWPitch.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.udDSPCWPitch)).EndInit();
             this.grpDSPKeyerOptions.ResumeLayout(false);
+            this.grpDSPKeyerOptions.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udCWKeyerWeight)).EndInit();
             this.grpDSPKeyerSemiBreakIn.ResumeLayout(false);
             this.grpDSPKeyerSemiBreakIn.PerformLayout();
@@ -56457,6 +56533,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS36)).EndInit();
             this.panelTS4.ResumeLayout(false);
             this.panelTS4.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutoModeSwitchCWReturn)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -59938,5 +60015,9 @@
         private CheckBoxTS chkQuickSplitPanAudio;
         private CheckBoxTS chkCancelQSplitOnCatTCIsplit;
         private CheckBoxTS chkJoinBandEdges;
+        private CheckBoxTS chkContainerNoTitle;
+        private LabelTS lblAutoModeSwitchCWms;
+        private NumericUpDownTS nudAutoModeSwitchCWReturn;
+        private CheckBoxTS chkAutoModeSwitchCWReturn;
     }
 }

--- a/Project Files/Source/Console/setup.resx
+++ b/Project Files/Source/Console/setup.resx
@@ -144,6 +144,9 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>302, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>302, 17</value>
+  </metadata>
   <data name="richTextBox1.Text" xml:space="preserve">
     <value>Begin with all spinners set equal to their labelled value.
 For each spinner, from minimum to maximum, adjust the output power
@@ -187,9 +190,6 @@ If Windows Firewall Pops up on the screen, Click on the Allow access.</value>
   </data>
   <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>162, 17</value>
-  </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>302, 17</value>
   </metadata>
   <data name="lblTXProfileWarning.ToolTip" xml:space="preserve">
     <value>One or more settings have been changed that are

--- a/Project Files/Source/Console/ucMeter.cs
+++ b/Project Files/Source/Console/ucMeter.cs
@@ -39,6 +39,7 @@ namespace Thetis
             _console = null;
             _id = System.Guid.NewGuid().ToString();
             _border = true;
+            _noTitleWhenPinned = false;
 
             btnFloat.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
 
@@ -78,6 +79,7 @@ namespace Thetis
         private bool _mox;
         private string _id;
         private bool _border;
+        private bool _noTitleWhenPinned;
 
         [Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
         public Console Console
@@ -312,9 +314,11 @@ namespace Thetis
         {
             bool bContains;
 
+
             if (!_dragging)
             {
-                bContains = pnlBar.ClientRectangle.Contains(pnlBar.PointToClient(Control.MousePosition));
+                bool noBar = _pinOnTop && _noTitleWhenPinned; //[2.10.1.0]MW0LGE no title when pinned has been chosen
+                bContains = !noBar && pnlBar.ClientRectangle.Contains(pnlBar.PointToClient(Control.MousePosition));
                 if (bContains && !pnlBar.Visible)
                 {
                     pnlBar.BringToFront();
@@ -473,7 +477,14 @@ namespace Thetis
                 setupBorder();
             }
         }
-
+        public bool NoTitleWhenPinned
+        {
+            get { return _noTitleWhenPinned; }
+            set
+            {
+                _noTitleWhenPinned = value;
+            }
+        }
         private void btnAxis_Click(object sender, EventArgs e)
         {
             MouseEventArgs me = (MouseEventArgs)e;
@@ -568,7 +579,8 @@ namespace Thetis
                 AxisLock.ToString() + "|" +
                 PinOnTop.ToString() + "|" +
                 UCBorder.ToString() + "|" +
-                Common.ColourToString(this.BackColor);
+                Common.ColourToString(this.BackColor) + "|" +
+                NoTitleWhenPinned.ToString();
         }
         public bool TryParse(string str)
         {
@@ -577,11 +589,12 @@ namespace Thetis
             bool floating = false;
             bool pinOnTop = false;
             bool border = false;
+            bool noTitleWhenPinned = false;
 
             if (str != "")
             {
                 string[] tmp = str.Split('|');
-                if(tmp.Length == 13)
+                if(tmp.Length >= 13 && tmp.Length <= 14)
                 {
                     bOk = tmp[0] != "";
                     if (bOk) ID = tmp[0];
@@ -623,6 +636,12 @@ namespace Thetis
                     Color c = Common.ColourFromString(tmp[12]);
                     bOk = c != System.Drawing.Color.Empty;
                     if(bOk) this.BackColor = c;
+
+                    if(bOk && tmp.Length > 13) // we also have the new for [2.10.1.0] the notitleifpined option
+                    {
+                        bOk = bool.TryParse(tmp[13], out noTitleWhenPinned);
+                        if (bOk) NoTitleWhenPinned = noTitleWhenPinned;
+                    }
                 }
             }
 


### PR DESCRIPTION
- No title bar for meter container option
- CW auto swap has been improved, now handles rx2, and has option in setup to return to previous mode after a duration
- meter items will fade if not in use in console. For example, turn off TXeq and the EQ meter will fade out