### PR TITLE
DUP TX Offset, WDSP SnapSpectrum timeout, Multimeter zeroout fix

### DIFF
--- a/Project Files/Source/Console/HPSDR/specHPSDR.cs
+++ b/Project Files/Source/Console/HPSDR/specHPSDR.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
+using System.Diagnostics;
 
 namespace Thetis
 {
@@ -731,7 +732,7 @@ namespace Thetis
         public static extern void SetCalibration(int disp, int set, int points, IntPtr cal);
 
         [DllImport("WDSP.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void SnapSpectrum(int disp, int ss, int LO, double* snap_buff);
+        public static extern void SnapSpectrum(int disp, int ss, int LO, double* snap_buff, int wait_ms, ref int flag);
 
         [DllImport("WDSP.dll", CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetDisplayDetectorMode (int disp, int pixout, int mode);

--- a/Project Files/Source/Console/common.cs
+++ b/Project Files/Source/Console/common.cs
@@ -802,10 +802,8 @@ namespace Thetis
 		{
 			if(str == "") return 0;
 
-            //MD5 md5Hasher = MD5.Create();
-            //byte[] hashed = md5Hasher.ComputeHash(Encoding.UTF8.GetBytes(str),);
-            //return BitConverter.ToInt32(hashed, 0) % 99999;
-
+            // Jenkins one_at_a_time hash function
+            // https://en.wikipedia.org/wiki/Jenkins_hash_function
             uint hash = 0;
             foreach (byte b in System.Text.Encoding.Unicode.GetBytes(str))
             {
@@ -816,6 +814,7 @@ namespace Thetis
             hash += (hash << 3);
             hash ^= (hash >> 11);
             hash += (hash << 15);
+
             return (int)(hash % 99999);
         }
         public static string ColourToString(System.Drawing.Color c)

--- a/Project Files/Source/Console/display.cs
+++ b/Project Files/Source/Console/display.cs
@@ -3260,7 +3260,7 @@ namespace Thetis
                                 DrawWaterfallDX2D(0, displayTargetWidth, m_nRX1DisplayHeight, 1, false);
                                 break;
                             case DisplayMode.HISTOGRAM:
-                                DrawHistogramDX2D(displayTargetWidth, m_nRX1DisplayHeight);
+                                DrawHistogramDX2D(1, displayTargetWidth, m_nRX1DisplayHeight);
                                 break;
                             case DisplayMode.PANAFALL:
                                 lock (m_objSplitDisplayLock)
@@ -3322,7 +3322,7 @@ namespace Thetis
                                 DrawWaterfallDX2D(0, displayTargetWidth, m_nRX1DisplayHeight, 1, false);
                                 break;
                             case DisplayMode.HISTOGRAM:
-                                DrawHistogramDX2D(displayTargetWidth, m_nRX1DisplayHeight);
+                                DrawHistogramDX2D(1, displayTargetWidth, m_nRX1DisplayHeight);
                                 break;
                             case DisplayMode.PANAFALL:
                                 m_nRX1DisplayHeight = displayTargetHeight / 4;
@@ -4006,7 +4006,11 @@ namespace Thetis
                 bool local_mox = mox && (!tx_on_vfob || (tx_on_vfob && !console.RX2Enabled));
                 bool displayduplex = isRxDuplex(1);
 
-                if (local_mox) fOffset = tx_display_cal_offset;
+                if (local_mox)
+                {
+                    fOffset = tx_display_cal_offset;
+                    if (displayduplex) fOffset += rx1_display_cal_offset;
+                }
                 else if (mox && tx_on_vfob && !displayduplex)
                 {
                     if (console.RX2Enabled) fOffset = rx1_display_cal_offset;
@@ -8548,15 +8552,16 @@ namespace Thetis
                 max = current_display_data_bottom[0];
             }
 
-            if (!mox || (mox && tx_on_vfob && console.RX2Enabled))
-            {
-                if (rx == 1/*!bottom*/) max += rx1_display_cal_offset; //MW0LGE_21g
-                else max += rx2_display_cal_offset;
-            }
-            else
-            {
-                max += tx_display_cal_offset;
-            }
+            //if (!mox || (mox && tx_on_vfob && console.RX2Enabled))
+            //{
+            //    if (rx == 1/*!bottom*/) max += rx1_display_cal_offset; //MW0LGE_21g
+            //    else max += rx2_display_cal_offset;
+            //}
+            //else
+            //{
+            //    max += tx_display_cal_offset;
+            //}
+            max += rx == 1 ? RX1Offset : RX2Offset;
 
             if (!mox || (mox && tx_on_vfob && console.RX2Enabled))
             {
@@ -8567,6 +8572,8 @@ namespace Thetis
             Y = (int)Math.Min((Math.Floor((grid_max - max) * H / yRange)), H);
             previousPoint.X = 0;// + 0.5f; // the 0.5f pushes it into the middle of a 'pixel', so that it is not drawn half in one, and half in the other
             previousPoint.Y = Y;// + 0.5f;
+
+            float fOffset = rx == 1 ? RX1Offset : RX2Offset;
 
             for (int i = 0; i < nDecimatedWidth; i++)
             {
@@ -8579,15 +8586,16 @@ namespace Thetis
                     max = current_display_data_bottom[i];
                 }
 
-                if (!mox || (mox && tx_on_vfob && console.RX2Enabled))
-                {
-                    if (rx == 1/*!bottom*/) max += rx1_display_cal_offset; //MW0LGE_21g
-                    else max += rx2_display_cal_offset;
-                }
-                else
-                {
-                    max += tx_display_cal_offset;
-                }
+                //if (!mox || (mox && tx_on_vfob && console.RX2Enabled))
+                //{
+                //    if (rx == 1/*!bottom*/) max += rx1_display_cal_offset; //MW0LGE_21g
+                //    else max += rx2_display_cal_offset;
+                //}
+                //else
+                //{
+                //    max += tx_display_cal_offset;
+                //}
+                max += fOffset;
 
                 if (!mox || (mox && tx_on_vfob && console.RX2Enabled))
                 {
@@ -9411,7 +9419,7 @@ namespace Thetis
             }
         }
 
-        unsafe static private bool DrawHistogramDX2D(int W, int H)
+        unsafe static private bool DrawHistogramDX2D(int rx, int W, int H)
         {
             DrawSpectrumGridDX2D(W, H, false);
 
@@ -9458,19 +9466,21 @@ namespace Thetis
             }
 
             int sum = 0;
+            float fOffset = rx == 1 ? RX1Offset : RX2Offset;
 
             for (int i = 0; i < nDecimatedWidth; i++)
             {
                 float max = max = current_display_data[i];
 
-                if (!mox)
-                {
-                    max += rx1_display_cal_offset;
-                }
-                else
-                {
-                    max += tx_display_cal_offset;
-                }
+                //if (!mox)
+                //{
+                //    max += rx1_display_cal_offset;
+                //}
+                //else
+                //{
+                //    max += tx_display_cal_offset;
+                //}
+                max += fOffset;
 
                 if (!mox) max += (rx1_preamp_offset - alex_preamp_offset);
 

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -2138,6 +2138,9 @@
             this.lblDSPCWPitchFreq = new System.Windows.Forms.LabelTS();
             this.udDSPCWPitch = new System.Windows.Forms.NumericUpDownTS();
             this.grpDSPKeyerOptions = new System.Windows.Forms.GroupBoxTS();
+            this.lblAutoModeSwitchCWms = new System.Windows.Forms.LabelTS();
+            this.nudAutoModeSwitchCWReturn = new System.Windows.Forms.NumericUpDownTS();
+            this.chkAutoModeSwitchCWReturn = new System.Windows.Forms.CheckBoxTS();
             this.udCWKeyerWeight = new System.Windows.Forms.NumericUpDownTS();
             this.chkDSPKeyerSidetone = new System.Windows.Forms.CheckBoxTS();
             this.chkStrictCharSpacing = new System.Windows.Forms.CheckBoxTS();
@@ -3479,9 +3482,6 @@
             this.radioButtonTS6 = new System.Windows.Forms.RadioButtonTS();
             this.tmrCheckProfile = new System.Windows.Forms.Timer(this.components);
             this.txtboxTXProfileChangedReport = new System.Windows.Forms.TextBoxTS();
-            this.chkAutoModeSwitchCWReturn = new System.Windows.Forms.CheckBoxTS();
-            this.nudAutoModeSwitchCWReturn = new System.Windows.Forms.NumericUpDownTS();
-            this.lblAutoModeSwitchCWms = new System.Windows.Forms.LabelTS();
             tpAlexAntCtrl = new System.Windows.Forms.TabPage();
             numericUpDownTS3 = new System.Windows.Forms.NumericUpDownTS();
             numericUpDownTS4 = new System.Windows.Forms.NumericUpDownTS();
@@ -3936,6 +3936,7 @@
             this.grpDSPCWPitch.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udDSPCWPitch)).BeginInit();
             this.grpDSPKeyerOptions.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutoModeSwitchCWReturn)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.udCWKeyerWeight)).BeginInit();
             this.grpDSPKeyerSemiBreakIn.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.udCWBreakInDelay)).BeginInit();
@@ -4401,7 +4402,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS35)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS36)).BeginInit();
             this.panelTS4.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudAutoModeSwitchCWReturn)).BeginInit();
             this.SuspendLayout();
             // 
             // tpAlexAntCtrl
@@ -9804,7 +9804,7 @@
             this.grpBoxTXDisplayCal.Controls.Add(this.udTXDisplayCalOffset);
             this.grpBoxTXDisplayCal.Location = new System.Drawing.Point(360, 126);
             this.grpBoxTXDisplayCal.Name = "grpBoxTXDisplayCal";
-            this.grpBoxTXDisplayCal.Size = new System.Drawing.Size(168, 105);
+            this.grpBoxTXDisplayCal.Size = new System.Drawing.Size(168, 80);
             this.grpBoxTXDisplayCal.TabIndex = 13;
             this.grpBoxTXDisplayCal.TabStop = false;
             this.grpBoxTXDisplayCal.Text = "TX Display Cal";
@@ -9812,12 +9812,12 @@
             // labelTS55
             // 
             this.labelTS55.Image = null;
-            this.labelTS55.Location = new System.Drawing.Point(32, 39);
+            this.labelTS55.Location = new System.Drawing.Point(26, 34);
             this.labelTS55.Name = "labelTS55";
             this.labelTS55.Size = new System.Drawing.Size(54, 23);
             this.labelTS55.TabIndex = 13;
             this.labelTS55.Text = "Offset:";
-            this.labelTS55.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.labelTS55.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // udTXDisplayCalOffset
             // 
@@ -9827,7 +9827,7 @@
             0,
             0,
             65536});
-            this.udTXDisplayCalOffset.Location = new System.Drawing.Point(92, 42);
+            this.udTXDisplayCalOffset.Location = new System.Drawing.Point(86, 37);
             this.udTXDisplayCalOffset.Maximum = new decimal(new int[] {
             100,
             0,
@@ -34482,6 +34482,58 @@
             this.grpDSPKeyerOptions.TabStop = false;
             this.grpDSPKeyerOptions.Text = "Options";
             // 
+            // lblAutoModeSwitchCWms
+            // 
+            this.lblAutoModeSwitchCWms.AutoSize = true;
+            this.lblAutoModeSwitchCWms.Image = null;
+            this.lblAutoModeSwitchCWms.Location = new System.Drawing.Point(160, 141);
+            this.lblAutoModeSwitchCWms.Name = "lblAutoModeSwitchCWms";
+            this.lblAutoModeSwitchCWms.Size = new System.Drawing.Size(20, 13);
+            this.lblAutoModeSwitchCWms.TabIndex = 50;
+            this.lblAutoModeSwitchCWms.Text = "ms";
+            // 
+            // nudAutoModeSwitchCWReturn
+            // 
+            this.nudAutoModeSwitchCWReturn.Increment = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.nudAutoModeSwitchCWReturn.Location = new System.Drawing.Point(98, 137);
+            this.nudAutoModeSwitchCWReturn.Maximum = new decimal(new int[] {
+            10000,
+            0,
+            0,
+            0});
+            this.nudAutoModeSwitchCWReturn.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.nudAutoModeSwitchCWReturn.Name = "nudAutoModeSwitchCWReturn";
+            this.nudAutoModeSwitchCWReturn.Size = new System.Drawing.Size(56, 20);
+            this.nudAutoModeSwitchCWReturn.TabIndex = 49;
+            this.nudAutoModeSwitchCWReturn.TinyStep = false;
+            this.toolTip1.SetToolTip(this.nudAutoModeSwitchCWReturn, "Selects the preferred CW tone frequency.");
+            this.nudAutoModeSwitchCWReturn.Value = new decimal(new int[] {
+            2000,
+            0,
+            0,
+            0});
+            this.nudAutoModeSwitchCWReturn.ValueChanged += new System.EventHandler(this.nudAutoModeSwitchCWReturn_ValueChanged);
+            // 
+            // chkAutoModeSwitchCWReturn
+            // 
+            this.chkAutoModeSwitchCWReturn.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.chkAutoModeSwitchCWReturn.Image = null;
+            this.chkAutoModeSwitchCWReturn.Location = new System.Drawing.Point(29, 138);
+            this.chkAutoModeSwitchCWReturn.Name = "chkAutoModeSwitchCWReturn";
+            this.chkAutoModeSwitchCWReturn.Size = new System.Drawing.Size(63, 16);
+            this.chkAutoModeSwitchCWReturn.TabIndex = 48;
+            this.chkAutoModeSwitchCWReturn.Text = "Return";
+            this.toolTip1.SetToolTip(this.chkAutoModeSwitchCWReturn, "Return to previous mode");
+            this.chkAutoModeSwitchCWReturn.CheckedChanged += new System.EventHandler(this.chkAutoModeSwitchCWReturn_CheckedChanged);
+            // 
             // udCWKeyerWeight
             // 
             this.udCWKeyerWeight.Increment = new decimal(new int[] {
@@ -55370,58 +55422,6 @@
             this.txtboxTXProfileChangedReport.Text = "used to report tx profile changes if you click on oragne box";
             this.txtboxTXProfileChangedReport.Visible = false;
             // 
-            // chkAutoModeSwitchCWReturn
-            // 
-            this.chkAutoModeSwitchCWReturn.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.chkAutoModeSwitchCWReturn.Image = null;
-            this.chkAutoModeSwitchCWReturn.Location = new System.Drawing.Point(29, 138);
-            this.chkAutoModeSwitchCWReturn.Name = "chkAutoModeSwitchCWReturn";
-            this.chkAutoModeSwitchCWReturn.Size = new System.Drawing.Size(63, 16);
-            this.chkAutoModeSwitchCWReturn.TabIndex = 48;
-            this.chkAutoModeSwitchCWReturn.Text = "Return";
-            this.toolTip1.SetToolTip(this.chkAutoModeSwitchCWReturn, "Return to previous mode");
-            this.chkAutoModeSwitchCWReturn.CheckedChanged += new System.EventHandler(this.chkAutoModeSwitchCWReturn_CheckedChanged);
-            // 
-            // nudAutoModeSwitchCWReturn
-            // 
-            this.nudAutoModeSwitchCWReturn.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.nudAutoModeSwitchCWReturn.Location = new System.Drawing.Point(98, 137);
-            this.nudAutoModeSwitchCWReturn.Maximum = new decimal(new int[] {
-            10000,
-            0,
-            0,
-            0});
-            this.nudAutoModeSwitchCWReturn.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.nudAutoModeSwitchCWReturn.Name = "nudAutoModeSwitchCWReturn";
-            this.nudAutoModeSwitchCWReturn.Size = new System.Drawing.Size(56, 20);
-            this.nudAutoModeSwitchCWReturn.TabIndex = 49;
-            this.nudAutoModeSwitchCWReturn.TinyStep = false;
-            this.toolTip1.SetToolTip(this.nudAutoModeSwitchCWReturn, "Selects the preferred CW tone frequency.");
-            this.nudAutoModeSwitchCWReturn.Value = new decimal(new int[] {
-            2000,
-            0,
-            0,
-            0});
-            this.nudAutoModeSwitchCWReturn.ValueChanged += new System.EventHandler(this.nudAutoModeSwitchCWReturn_ValueChanged);
-            // 
-            // lblAutoModeSwitchCWms
-            // 
-            this.lblAutoModeSwitchCWms.AutoSize = true;
-            this.lblAutoModeSwitchCWms.Image = null;
-            this.lblAutoModeSwitchCWms.Location = new System.Drawing.Point(160, 141);
-            this.lblAutoModeSwitchCWms.Name = "lblAutoModeSwitchCWms";
-            this.lblAutoModeSwitchCWms.Size = new System.Drawing.Size(20, 13);
-            this.lblAutoModeSwitchCWms.TabIndex = 50;
-            this.lblAutoModeSwitchCWms.Text = "ms";
-            // 
             // Setup
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
@@ -55992,6 +55992,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.udDSPCWPitch)).EndInit();
             this.grpDSPKeyerOptions.ResumeLayout(false);
             this.grpDSPKeyerOptions.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudAutoModeSwitchCWReturn)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.udCWKeyerWeight)).EndInit();
             this.grpDSPKeyerSemiBreakIn.ResumeLayout(false);
             this.grpDSPKeyerSemiBreakIn.PerformLayout();
@@ -56533,7 +56534,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownTS36)).EndInit();
             this.panelTS4.ResumeLayout(false);
             this.panelTS4.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudAutoModeSwitchCWReturn)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/Project Files/Source/Console/setup.resx
+++ b/Project Files/Source/Console/setup.resx
@@ -141,12 +141,6 @@
   <metadata name="numericUpDownTS12.GenerateMember" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>302, 17</value>
-  </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>302, 17</value>
-  </metadata>
   <data name="richTextBox1.Text" xml:space="preserve">
     <value>Begin with all spinners set equal to their labelled value.
 For each spinner, from minimum to maximum, adjust the output power
@@ -159,16 +153,6 @@ POWER EXCEEDING THE RATING OF YOUR RADIO!
   </data>
   <data name="lgLinearGradientRX1.EncodedText" xml:space="preserve">
     <value>OXwxfDAuMDAwfC0xNjc3NzIxNnwwfDAuMTI1fC0xNDczNzYzM3wwfDAuMjUwfC0xMjY5ODA1MHwwfDAuMzc1fC0xMDY1ODQ2N3wwfDAuNTAwfC04NjE4ODg0fDB8MC42MjV8LTY1NzkzMDF8MHwwLjc1MHwtNDUzOTcxOHwwfDAuODc1fC0yNTAwMTM1fDF8MS4wMDB8LTF8</value>
-  </data>
-  <data name="groupBox2.ToolTip" xml:space="preserve">
-    <value>Allows you to view the Display are of Thetis remotely
-
-To view your Display.
-1) Locate the IP address off your computer (example: 192.168.1.100)
-2) Open your Web browser and type:  http://&lt;your local IP address&gt;:8081
-
-
-</value>
   </data>
   <data name="udHttpRefresh.ToolTip" xml:space="preserve">
     <value>Select Port# to allow Remote Login by adding the Port# 
@@ -187,6 +171,16 @@ or http://localhost:8081
 
 But you must also add this port# to your Routers "Port Forward" options
 If Windows Firewall Pops up on the screen, Click on the Allow access.</value>
+  </data>
+  <data name="groupBox2.ToolTip" xml:space="preserve">
+    <value>Allows you to view the Display are of Thetis remotely
+
+To view your Display.
+1) Locate the IP address off your computer (example: 192.168.1.100)
+2) Open your Web browser and type:  http://&lt;your local IP address&gt;:8081
+
+
+</value>
   </data>
   <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>162, 17</value>

--- a/Project Files/Source/wdsp/analyzer.c
+++ b/Project Files/Source/wdsp/analyzer.c
@@ -1267,12 +1267,32 @@ PORT
 void SnapSpectrum(	int disp,
 					int ss,
 					int LO,
-					double *snap_buff)
+					double *snap_buff,
+					int wait_ms,		//wait for milliseconds, < 0 infinte
+					int *flag			//else, returns 0 (try again later)
+					)
 {
 	DP a = pdisp[disp];
 	a->snap_buff[ss][LO] = snap_buff;
 	InterlockedBitTestAndSet(&(a->snap[ss][LO]), 0);
-	WaitForSingleObject(a->hSnapEvent[ss][LO], INFINITE);
+
+	DWORD result;
+	if (wait_ms < 0)
+	{
+		result = WaitForSingleObject(a->hSnapEvent[ss][LO], INFINITE);
+	}
+	else
+	{
+		result = WaitForSingleObject(a->hSnapEvent[ss][LO], wait_ms);
+	}
+	if (result == 0)
+	{
+		*flag = 1;
+	}
+	else
+	{
+		*flag = 0;
+	}
 }
 
 int calcompare (const void * a, const void * b)

--- a/Project Files/Source/wdsp/analyzer.h
+++ b/Project Files/Source/wdsp/analyzer.h
@@ -183,6 +183,9 @@ extern __declspec( dllexport )
 void SnapSpectrum(	int disp,
 					int ss,
 					int LO,
-					double *snap_buff);
+					double *snap_buff,
+					int wait_ms,
+					int *flag
+					);
 
 #endif


### PR DESCRIPTION
RxDisplayCalibration offset is now applied when in DUP mode TX on rx1. Fixes issue #137 
WDSP SnapSpectrum can infinite wait, added time out options
Multimeters would not reset to S0 when above 30MHz. Now fixed.