### PR TITLE
skin server uri redirect handled, phase reverse, midi status

### DIFF
--- a/Project Files/Source/Console/clsThetisSkinService.cs
+++ b/Project Files/Source/Console/clsThetisSkinService.cs
@@ -77,6 +77,7 @@ namespace Thetis
         public long BytesDownloaded { get; set; }
         public long TotalBytes { get; set; }
         public string Url { get; set; }
+        public string FinalUri { get; set; }
         public bool Complete {  get; set; }
         public bool Cancelled { get; set; }
         public int PercentageDownloaded { get; set; }
@@ -316,7 +317,12 @@ namespace Thetis
                             sfd.Path = savePath;
                             sfd.TotalBytes = totalBytes;
                             sfd.Complete = false;
-                            sfd.PercentageDownloaded = 0;                            
+                            sfd.PercentageDownloaded = 0;
+                            if (response.RequestMessage != null)
+                            {
+                                Uri finalUri = response.RequestMessage.RequestUri;
+                                sfd.FinalUri = finalUri.ToString();
+                            }
 
                             FileDownload?.Invoke(null, sfd);
                             int buffLen = 4096;
@@ -352,6 +358,10 @@ namespace Thetis
                             sfd.Cancelled = false;
 
                             FileDownload?.Invoke(null, sfd);
+                        }
+                        else
+                        {
+                            FileDownload?.Invoke(null, null);
                         }
                     }
                 }

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -2395,6 +2395,7 @@ namespace Thetis
             chkSpotOwnCallAppearance_CheckedChanged(this, EventArgs.Empty);
 
             chkIgnore14bitMidiMessages_CheckedChanged(this, EventArgs.Empty);
+            chkMidiControlIDincludesChannel_CheckedChanged(this, EventArgs.Empty);
             chkMidiControlIDincludesStatus_CheckedChanged(this, EventArgs.Empty);
 
             // SNB
@@ -28309,7 +28310,7 @@ namespace Thetis
             if (ts.SkinUrl != "" && Common.IsValidUri(ts.SkinUrl))
             {
                 btnDownloadSkin.Tag = ts.SkinUrl.Left(1024);
-                btnDownloadSkin.Enabled = Common.CompareVersions(ts.FromThetisVersion, Common.GetVerNum()) <= 0;
+                btnDownloadSkin.Enabled = Common.CompareVersions(ts.FromThetisVersion, Common.GetFileVersion()) <= 0;
             }
             else
             {
@@ -28449,6 +28450,8 @@ namespace Thetis
                     Debug.Print(e.BytesDownloaded.ToString() + " - " + e.TotalBytes.ToString());
 
                     string sFile = getFileFromUrl(e.Url);
+                    if(sFile == "")
+                        sFile = getFileFromUrl(e.FinalUri);
 
                     if (isSkinZipFile(e.Path, sFile, out bool bUsesFileInRoot, out bool bMeterFolderFound, e.BypassRootFolderCheck | e.IsMeterSkin))
                     {
@@ -28888,7 +28891,7 @@ namespace Thetis
         private void chkPHROTReverse_CheckedChanged(object sender, EventArgs e)
         {
             if (initializing) return;
-            int run = chkPHROTEnable.Checked ? 1 : 0;
+            int run = chkPHROTReverse.Checked ? 1 : 0;
             WDSP.SetTXAPHROTReverse(WDSP.id(1, 0), run);
         }
 
@@ -28991,10 +28994,18 @@ namespace Thetis
             MidiDevice.Ignore14bitMessages = chkIgnore14bitMidiMessages.Checked;
         }
 
+        private void chkMidiControlIDincludesChannel_CheckedChanged(object sender, EventArgs e)
+        {
+            if (initializing) return;
+            MidiDevice.BuildIDFromControlIDAndChannel = chkMidiControlIDincludesChannel.Checked;
+            MidiDevice.IncludeStatusInControlID  = chkMidiControlIDincludesChannel.Checked && chkMidiControlIDincludesStatus.Checked;
+            chkMidiControlIDincludesStatus.Enabled = chkMidiControlIDincludesChannel.Checked;
+        }
+
         private void chkMidiControlIDincludesStatus_CheckedChanged(object sender, EventArgs e)
         {
             if (initializing) return;
-            MidiDevice.BuildIDFromControlIDAndStatus = chkMidiControlIDincludesStatus.Checked;
+            MidiDevice.IncludeStatusInControlID = chkMidiControlIDincludesChannel.Checked && chkMidiControlIDincludesStatus.Checked;
         }
 
         //private bool renameSkinForDeletion(string sFullPath)

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -3337,6 +3337,7 @@
             this.tbMIDIcat = new System.Windows.Forms.TabPage();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.chkMidiControlIDincludesStatus = new System.Windows.Forms.CheckBoxTS();
+            this.chkMidiControlIDincludesChannel = new System.Windows.Forms.CheckBoxTS();
             this.chkIgnore14bitMidiMessages = new System.Windows.Forms.CheckBoxTS();
             this.udUpdatesPerStepMin = new System.Windows.Forms.NumericUpDownTS();
             this.labelTS511 = new System.Windows.Forms.LabelTS();
@@ -52957,6 +52958,7 @@
             // groupBox1
             // 
             this.groupBox1.Controls.Add(this.chkMidiControlIDincludesStatus);
+            this.groupBox1.Controls.Add(this.chkMidiControlIDincludesChannel);
             this.groupBox1.Controls.Add(this.chkIgnore14bitMidiMessages);
             this.groupBox1.Controls.Add(this.udUpdatesPerStepMin);
             this.groupBox1.Controls.Add(this.labelTS511);
@@ -52966,7 +52968,7 @@
             this.groupBox1.Controls.Add(this.btnConfigure);
             this.groupBox1.Location = new System.Drawing.Point(14, 15);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(337, 158);
+            this.groupBox1.Size = new System.Drawing.Size(337, 176);
             this.groupBox1.TabIndex = 105;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "MIDI Configuration";
@@ -52975,14 +52977,28 @@
             // 
             this.chkMidiControlIDincludesStatus.AutoSize = true;
             this.chkMidiControlIDincludesStatus.Image = null;
-            this.chkMidiControlIDincludesStatus.Location = new System.Drawing.Point(165, 134);
+            this.chkMidiControlIDincludesStatus.Location = new System.Drawing.Point(179, 153);
             this.chkMidiControlIDincludesStatus.Name = "chkMidiControlIDincludesStatus";
-            this.chkMidiControlIDincludesStatus.Size = new System.Drawing.Size(156, 17);
-            this.chkMidiControlIDincludesStatus.TabIndex = 114;
-            this.chkMidiControlIDincludesStatus.Text = "Control ID includes channel";
-            this.toolTip1.SetToolTip(this.chkMidiControlIDincludesStatus, resources.GetString("chkMidiControlIDincludesStatus.ToolTip"));
+            this.chkMidiControlIDincludesStatus.Size = new System.Drawing.Size(114, 17);
+            this.chkMidiControlIDincludesStatus.TabIndex = 115;
+            this.chkMidiControlIDincludesStatus.Text = "Also include status";
+            this.toolTip1.SetToolTip(this.chkMidiControlIDincludesStatus, "Note: the control ID will now\r\nbe made as follows : controlIDmapped = ((controlId" +
+        " & 0xFF) << 16) | ((channel & 0xFF) << 8) | (status & 0xFF);");
             this.chkMidiControlIDincludesStatus.UseVisualStyleBackColor = true;
             this.chkMidiControlIDincludesStatus.CheckedChanged += new System.EventHandler(this.chkMidiControlIDincludesStatus_CheckedChanged);
+            // 
+            // chkMidiControlIDincludesChannel
+            // 
+            this.chkMidiControlIDincludesChannel.AutoSize = true;
+            this.chkMidiControlIDincludesChannel.Image = null;
+            this.chkMidiControlIDincludesChannel.Location = new System.Drawing.Point(165, 134);
+            this.chkMidiControlIDincludesChannel.Name = "chkMidiControlIDincludesChannel";
+            this.chkMidiControlIDincludesChannel.Size = new System.Drawing.Size(156, 17);
+            this.chkMidiControlIDincludesChannel.TabIndex = 114;
+            this.chkMidiControlIDincludesChannel.Text = "Control ID includes channel";
+            this.toolTip1.SetToolTip(this.chkMidiControlIDincludesChannel, resources.GetString("chkMidiControlIDincludesChannel.ToolTip"));
+            this.chkMidiControlIDincludesChannel.UseVisualStyleBackColor = true;
+            this.chkMidiControlIDincludesChannel.CheckedChanged += new System.EventHandler(this.chkMidiControlIDincludesChannel_CheckedChanged);
             // 
             // chkIgnore14bitMidiMessages
             // 
@@ -60947,6 +60963,7 @@
         private CheckBoxTS chkVAC2ExclusiveIn;
         private ButtonTS btnReleaseNotes;
         private CheckBoxTS chkIgnore14bitMidiMessages;
+        private CheckBoxTS chkMidiControlIDincludesChannel;
         private CheckBoxTS chkMidiControlIDincludesStatus;
     }
 }

--- a/Project Files/Source/Console/setup.resx
+++ b/Project Files/Source/Console/setup.resx
@@ -286,7 +286,7 @@ only used if a selected skin does not provide its own.</value>
         X2Aj4NZ79wh2Mf6UNhJytIqS5B20I3/Xm75I8AAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="chkMidiControlIDincludesStatus.ToolTip" xml:space="preserve">
+  <data name="chkMidiControlIDincludesChannel.ToolTip" xml:space="preserve">
     <value>Some devices use the same control ID for multiple buttons/knobs etc.
 Use this option to combine the midi channel value with the control id, this
 should then uniquely identify each control. Note: the control ID will now

--- a/Project Files/Source/Console/titlebar.cs
+++ b/Project Files/Source/Console/titlebar.cs
@@ -34,7 +34,7 @@ namespace Thetis
 {
     class TitleBar
     {
-        public const string BUILD_NAME = "pre-release-4";
+        public const string BUILD_NAME = "pre-release-5";
 
         public static string GetString(bool bWithFirmware = true)
         {

--- a/Project Files/Source/Midi2Cat/Midi2Cat.IO/MidiDevice.cs
+++ b/Project Files/Source/Midi2Cat/Midi2Cat.IO/MidiDevice.cs
@@ -56,7 +56,8 @@ namespace Midi2Cat.IO
         public event MidiInputEventHandler onMidiInput;
         public event DebugMsgEventHandler onMidiDebugMessage;
 
-        static public bool BuildIDFromControlIDAndStatus = false; //[2.10.3.4]MW0LGE
+        static public bool BuildIDFromControlIDAndChannel = false; //[2.10.3.4]MW0LGE
+        static public bool IncludeStatusInControlID = false; //[2.10.3.4]MW0LGE
         static public bool Ignore14bitMessages = false; //[2.10.3.4]MW0LGE
         static public int VFOSelect;  //-W2PA for switching Behringer PL-1 main wheel between VFO A and B.  Used in inDevice_ChannelMessageReceived() below and in MidiDeviceSetup.cs
         public int latestControlID = 0;
@@ -643,15 +644,20 @@ namespace Midi2Cat.IO
                         // scrap first message for the vinal button as two arrive
                         if (controlId == 0x03 && channel == 0x01 && status == 0x91) return false;
 
-                        // controlID and the channel defines a button/control id with the starlight
+                        // controlID and the channel defines a button/control id with the starlight, fine to use 16 bits
                         controlIDmapped = ((controlId & 0xFF) << 8) | (channel & 0xFF);
 
                         break;
                     }
                 default :
                     {
-                        if (BuildIDFromControlIDAndStatus) // build a 16 bit ID from the controlID and the channel, as so many controlID's are duplicated for different buttons on some devices
-                            controlIDmapped = ((controlId & 0xFF) << 8) | (channel & 0xFF);
+                        if (BuildIDFromControlIDAndChannel) // build a 16/24 bit ID from the controlID and the channel and status, as so many controlID's are duplicated for different buttons on some devices
+                        {
+                            if (IncludeStatusInControlID)
+                                controlIDmapped = ((controlId & 0xFF) << 16) | ((channel & 0xFF) << 8) | (status & 0xFF);
+                            else
+                                controlIDmapped = ((controlId & 0xFF) << 8) | (channel & 0xFF);
+                        }
 
                         break;
                     }

--- a/Project Files/Source/ReleaseNotes.txt
+++ b/Project Files/Source/ReleaseNotes.txt
@@ -11,9 +11,9 @@ Please report any issue over on [GitHub here](https://github.com/ramdor/Thetis/i
 ## v2.10.3.4 Change Log
 - [add] show on startup options for ampview and linearity/ps window. Set in the linearity/ps window
 - [add] can now ignore 14bit Midi messages. More devices should work. Option in Setup->Serial/Network/Midi CAT->Midi
-- [add] can now combine midi control id and channel to be used as the control ID. This should allow devices that share controlIDs for multiple buttons/sliders to work. Option in Setup->Serial/Network/Midi CAT->Midi
+- [add] can now combine midi control id, channel and status to be used as the control ID. This should allow devices that share controlIDs for multiple buttons/sliders to work. Options in Setup->Serial/Network/Midi CAT->Midi
 - [add] certain skins might make it snow !
-- [fix] mic phase reverse now calling correct function in WDSP
+- [fix] mic phase reverse now calling correct function in WDSP, and can be turned on/off
 - [fix] Hercules DJControl Starlight midi device is now better handled. Wheel finger press for example are ignored. If you used this device before you will need to reconfigure as the control IDs will have changed
 - [fix] PortAudio #850 fix included
 - [fix] FM should now use low/high cuts. Carlson's rules used for filter width display in FM rx and tx


### PR DESCRIPTION
- skin server now works with redirects
- phase reverse now can be turned on/off (ooops)
- midi control ID can now also include status to make it 24 bit