### PR TITLE
bypass change events when tx profile checker is running via timer

### DIFF
--- a/Project Files/Source/Console/VersionInfo.cs
+++ b/Project Files/Source/Console/VersionInfo.cs
@@ -6,6 +6,6 @@ namespace Thetis
 { 
     public static class VersionInfo 
     { 
-        public static string BuildDate { get { return "11/27/23"; } }  
+        public static string BuildDate { get { return "11/28/23"; } }  
     } 
 } 

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -7725,7 +7725,7 @@ namespace Thetis
 
         private void chkGeneralRXOnly_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkGeneralRXOnly.Focused &&
                 !chkGeneralRXOnly.Checked)
             {
@@ -7839,18 +7839,18 @@ namespace Thetis
 
         private void chkGeneralDisablePTT_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.DisablePTT = chkGeneralDisablePTT.Checked;
         }
 
         private void comboGeneralXVTR_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
         }
 
         private void comboGeneralProcessPriority_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Process p = Process.GetCurrentProcess();
 
             if (comboGeneralProcessPriority.Text == "Real Time" &&
@@ -7969,13 +7969,13 @@ namespace Thetis
 
         private void udFilterDefaultLowCut_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.DefaultLowCut = (int)udFilterDefaultLowCut.Value;
         }
 
         private void udRX2FilterDefaultLowCut_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.DefaultRX2LowCut = (int)udRX2FilterDefaultLowCut.Value;
         }
 
@@ -7988,7 +7988,7 @@ namespace Thetis
 
         private void chkAudioEnableVAC_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool val = chkAudioEnableVAC.Checked;
             //bool old_val = console.VACEnabled;  //MW0LGE_21i not used
 
@@ -8007,7 +8007,7 @@ namespace Thetis
 
         private void chkVAC2Enable_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool val = chkVAC2Enable.Checked;
             //bool old_val = console.VAC2Enabled; //MW0LGE_21i not used
 
@@ -8313,7 +8313,7 @@ namespace Thetis
 
         private void comboAudioSampleRate1_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (comboAudioSampleRate1.SelectedIndex < 0) return;
 
             int old_rate = console.SampleRateRX1;
@@ -8493,7 +8493,7 @@ namespace Thetis
 
         private void comboAudioSampleRateRX2_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (comboAudioSampleRateRX2.SelectedIndex < 0) return;
 
             int old_rate = console.SampleRateRX2;
@@ -8553,7 +8553,7 @@ namespace Thetis
 
         private void comboAudioSampleRate2_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (comboAudioSampleRate2.SelectedIndex < 0) return;
 
             int old_rate = console.SampleRate2;
@@ -8629,7 +8629,7 @@ namespace Thetis
 
         private void comboAudioBuffer2_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (comboAudioBuffer2.SelectedIndex < 0) return;
 
             int old_size = console.BlockSize2;
@@ -8680,7 +8680,7 @@ namespace Thetis
 
         private void udAudioLatency2_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // RingBuffer In
             bool power = console.PowerOn;
             if (power && chkAudioEnableVAC.Checked)
@@ -8699,7 +8699,7 @@ namespace Thetis
 
         private void udAudioLatency2_Out_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // RingBuffer Out
             bool power = console.PowerOn;
             if (power && chkAudioEnableVAC.Checked)
@@ -8719,7 +8719,7 @@ namespace Thetis
 
         private void udAudioLatencyPAIn_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // PortAudio In
             bool power = console.PowerOn;
             if (power && chkAudioEnableVAC.Checked)
@@ -8738,7 +8738,7 @@ namespace Thetis
 
         private void udAudioLatencyPAOut_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // PortAudio Out
             bool power = console.PowerOn;
             if (power && chkAudioEnableVAC.Checked)
@@ -8757,7 +8757,7 @@ namespace Thetis
 
         private void udVAC2Latency_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkVAC2Enable.Checked)
             {
@@ -8775,7 +8775,7 @@ namespace Thetis
 
         private void udVAC2LatencyOut_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkVAC2Enable.Checked)
             {
@@ -8793,7 +8793,7 @@ namespace Thetis
 
         private void udVAC2LatencyPAIn_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkVAC2Enable.Checked)
             {
@@ -8811,7 +8811,7 @@ namespace Thetis
 
         private void udVAC2LatencyPAOut_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkVAC2Enable.Checked)
             {
@@ -8863,7 +8863,7 @@ namespace Thetis
 
         private void udAudioVACGainRX_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VACRXScale = Math.Pow(10.0, (int)udAudioVACGainRX.Value / 20.0);
             console.VACRXGain = (int)udAudioVACGainRX.Value;
             if (console.sliderForm != null)
@@ -8873,7 +8873,7 @@ namespace Thetis
 
         private void udVAC2GainRX_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2RXScale = Math.Pow(10.0, (int)udVAC2GainRX.Value / 20.0);
             console.VAC2RXGain = (int)udVAC2GainRX.Value;
             if (console.sliderForm != null)
@@ -8882,7 +8882,7 @@ namespace Thetis
 
         private void udAudioVACGainTX_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VACPreamp = Math.Pow(10.0, (int)udAudioVACGainTX.Value / 20.0);
             console.VACTXGain = (int)udAudioVACGainTX.Value;
             if (console.sliderForm != null)
@@ -8891,7 +8891,7 @@ namespace Thetis
 
         private void udVAC2GainTX_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2TXScale = Math.Pow(10.0, (int)udVAC2GainTX.Value / 20.0);
             console.VAC2TXGain = (int)udVAC2GainTX.Value;
             if (console.sliderForm != null)
@@ -8910,7 +8910,7 @@ namespace Thetis
 
         private void chkAudioLatencyManual2_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkAudioEnableVAC.Checked)
             {
@@ -8933,7 +8933,7 @@ namespace Thetis
 
         private void chkAudioLatencyManual2_Out_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkAudioEnableVAC.Checked)
             {
@@ -8956,7 +8956,7 @@ namespace Thetis
 
         private void chkAudioLatencyPAInManual_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkAudioEnableVAC.Checked)
             {
@@ -8979,7 +8979,7 @@ namespace Thetis
 
         private void chkAudioLatencyPAOutManual_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkAudioEnableVAC.Checked)
             {
@@ -9002,7 +9002,7 @@ namespace Thetis
 
         private void chkVAC2LatencyManual_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkVAC2Enable.Checked)
             {
@@ -9025,7 +9025,7 @@ namespace Thetis
 
         private void chkVAC2LatencyOutManual_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkVAC2Enable.Checked)
             {
@@ -9048,7 +9048,7 @@ namespace Thetis
 
         private void chkVAC2LatencyPAInManual_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkVAC2Enable.Checked)
             {
@@ -9065,7 +9065,7 @@ namespace Thetis
 
         private void chkVAC2LatencyPAOutManual_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool power = console.PowerOn;
             if (power && chkVAC2Enable.Checked)
             {
@@ -9115,7 +9115,7 @@ namespace Thetis
 
         private void udDisplayFPS_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.DisplayFPS = (int)udDisplayFPS.Value;
 
             //MW0LGE_21g ///*if(console.CurrentDisplayEngine == DisplayEngine.DIRECT_X)*/
@@ -9133,7 +9133,7 @@ namespace Thetis
 
         private void udDisplayGridMax_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             UpdateDisplayGridBandInfo();
             switch (console.RX1Band)
             {
@@ -9203,7 +9203,7 @@ namespace Thetis
 
         private void udDisplayGridMin_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             UpdateDisplayGridBandInfo();
             switch (console.RX1Band)
             {
@@ -9273,13 +9273,13 @@ namespace Thetis
 
         private void udDisplayGridStep_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.SpectrumGridStep = (int)udDisplayGridStep.Value;
         }
 
         private void udRX2DisplayGridMax_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // if (udRX2DisplayGridMax.Value <= udRX2DisplayGridMin.Value)
             //    udRX2DisplayGridMax.Value = udRX2DisplayGridMin.Value + 10;
             // Display.RX2SpectrumGridMax = (int)udRX2DisplayGridMax.Value;
@@ -9354,7 +9354,7 @@ namespace Thetis
 
         private void udRX2DisplayGridMin_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             UpdateDisplayGridBandInfo();
             switch (console.RX2Band)
             {
@@ -9422,7 +9422,7 @@ namespace Thetis
 
         private void udRX2DisplayGridStep_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX2SpectrumGridStep = (int)udRX2DisplayGridStep.Value;
         }
 
@@ -9453,13 +9453,13 @@ namespace Thetis
 
         private void udDisplayPhasePts_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.PhaseNumPts = (int)udDisplayPhasePts.Value;
         }
 
         private void udDisplayAVGTime_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(0).AvTau = 0.001 * (double)udDisplayAVGTime.Value;
             console.UpdateRXSpectrumDisplayVars();
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).AvTau = 0.001 * (double)udDisplayAVGTime.Value;
@@ -9471,31 +9471,31 @@ namespace Thetis
 
         private void udRX2DisplayAVGTime_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(1).AvTau = 0.001 * (double)udRX2DisplayAVGTime.Value;
         }
 
         private void udDisplayMeterDelay_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MeterDelay = (int)udDisplayMeterDelay.Value;
         }
 
         private void udDisplayPeakText_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.PeakTextDelay = (int)udDisplayPeakText.Value;
         }
 
         private void udDisplayCPUMeter_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.CPUMeterDelay = (int)udDisplayCPUMeter.Value;
         }
 
         private void clrbtnWaterfallLow_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.WaterfallLowColor = clrbtnWaterfallLow.Color;
         }
 
@@ -9511,7 +9511,7 @@ namespace Thetis
 
         private void udDisplayWaterfallLowLevel_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             UpdateWaterfallBandInfo();
             switch (console.RX1Band)
             {
@@ -9576,7 +9576,7 @@ namespace Thetis
 
         private void udDisplayWaterfallHighLevel_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             UpdateWaterfallBandInfo();
             switch (console.RX1Band)
             {
@@ -9641,20 +9641,20 @@ namespace Thetis
 
         private void udDisplayMultiPeakHoldTime_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MultimeterPeakHoldTime = (int)udDisplayMultiPeakHoldTime.Value;
         }
 
         private void udDisplayMultiTextHoldTime_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MultimeterTextPeakTime = (int)udDisplayMultiTextHoldTime.Value;
         }
 
         // RX2 WaterFall
         private void clrbtnRX2WaterfallLow_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX2WaterfallLowColor = clrbtnRX2WaterfallLow.Color;
         }
 
@@ -9670,7 +9670,7 @@ namespace Thetis
 
         private void udRX2DisplayWaterfallLowLevel_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             UpdateWaterfallBandInfo();
             switch (console.RX2Band)
             {
@@ -9735,7 +9735,7 @@ namespace Thetis
 
         private void udRX2DisplayWaterfallHighLevel_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             UpdateWaterfallBandInfo();
             switch (console.RX2Band)
             {
@@ -9832,7 +9832,7 @@ namespace Thetis
 
         private void udTXGridMax_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (udTXGridMax.Value <= udTXGridMin.Value)
                 udTXGridMax.Value = udTXGridMin.Value + 10;
             Display.TXSpectrumGridMax = (int)udTXGridMax.Value;
@@ -9840,7 +9840,7 @@ namespace Thetis
 
         private void udTXGridMin_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (udTXGridMin.Value >= udTXGridMax.Value)
                 udTXGridMin.Value = udTXGridMax.Value - 10;
             Display.TXSpectrumGridMin = (int)udTXGridMin.Value;
@@ -9848,7 +9848,7 @@ namespace Thetis
 
         private void udTXGridStep_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXSpectrumGridStep = (int)udTXGridStep.Value;
         }
 
@@ -9868,7 +9868,7 @@ namespace Thetis
 
         private void comboTXLabelAlign_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             switch (comboTXLabelAlign.Text)
             {
                 case "Left":
@@ -9901,7 +9901,7 @@ namespace Thetis
 
         private void udLMSNR_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).SetNRVals(
                 (int)udLMSNRtaps.Value,
                 (int)udLMSNRdelay.Value,
@@ -9916,7 +9916,7 @@ namespace Thetis
 
         private void udLMSNR2_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).SetNRVals(
                 (int)udLMSNR2taps.Value,
                 (int)udLMSNR2delay.Value,
@@ -9931,7 +9931,7 @@ namespace Thetis
 
         private void udDSPNB_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).NBThreshold = 0.165 * (double)(udDSPNB.Value);
             console.radio.GetDSPRX(1, 0).NBThreshold = 0.165 * (double)(udDSPNB.Value);
         }
@@ -10045,7 +10045,7 @@ namespace Thetis
 
         private void udLMSANF_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).SetANFVals(
                 (int)udLMSANFtaps.Value,
                 (int)udLMSANFdelay.Value,
@@ -10060,7 +10060,7 @@ namespace Thetis
 
         private void udLMSANF2_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).SetANFVals(
                 (int)udLMSANF2taps.Value,
                 (int)udLMSANF2delay.Value,
@@ -10075,7 +10075,7 @@ namespace Thetis
 
         private void radANFPreAGC_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int position;
             if (radANFPreAGC.Checked)
                 position = 0;
@@ -10091,7 +10091,7 @@ namespace Thetis
 
         private void radANF2PreAGC_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int position;
             if (radANF2PreAGC.Checked)
                 position = 0;
@@ -10108,13 +10108,13 @@ namespace Thetis
 
         private void udDSPCWPitch_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.CWPitch = (int)udDSPCWPitch.Value;
         }
 
         private void chkCWKeyerIambic_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.CWIambic = chkCWKeyerIambic.Checked;
             if (chkCWKeyerIambic.Checked)
                 NetworkIO.SetCWIambic(1);
@@ -10123,7 +10123,7 @@ namespace Thetis
 
         private void udCWKeyerWeight_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             NetworkIO.SetCWKeyerWeight((int)udCWKeyerWeight.Value);
         }
 
@@ -10138,7 +10138,7 @@ namespace Thetis
 
         private void chkCWBreakInEnabled_CheckStateChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.BreakInEnabledState = chkCWBreakInEnabled.CheckState;
 
             switch (chkCWBreakInEnabled.CheckState)
@@ -10177,7 +10177,7 @@ namespace Thetis
 
         private void chkDSPKeyerSidetone_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.CWSidetone = chkDSPKeyerSidetone.Checked;
             if (chkDSPKeyerSidetone.Checked)
                 NetworkIO.SetCWSidetone(1);
@@ -10187,7 +10187,7 @@ namespace Thetis
 
         private void chkCWKeyerRevPdl_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.ReversePaddles = chkCWKeyerRevPdl.Checked;
         }
 
@@ -10328,7 +10328,7 @@ namespace Thetis
 
         private void udDSPAGCFixedGaindB_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXFixedAGC = (double)udDSPAGCFixedGaindB.Value;
             console.radio.GetDSPRX(0, 1).RXFixedAGC = (double)udDSPAGCFixedGaindB.Value;
 
@@ -10338,7 +10338,7 @@ namespace Thetis
 
         private void udDSPAGCMaxGaindB_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXAGCMaxGain = (double)udDSPAGCMaxGaindB.Value;
             console.radio.GetDSPRX(0, 1).RXAGCMaxGain = (double)udDSPAGCMaxGaindB.Value;
 
@@ -10348,7 +10348,7 @@ namespace Thetis
 
         private void udDSPAGCRX2MaxGaindB_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXAGCMaxGain = (double)udDSPAGCRX2MaxGaindB.Value;
             // console.radio.GetDSPRX(1, 1).RXAGCMaxGain = (double)udDSPAGCRX2MaxGaindB.Value;
 
@@ -10358,7 +10358,7 @@ namespace Thetis
 
         private void udDSPAGCRX2FixedGaindB_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXFixedAGC = (double)udDSPAGCRX2FixedGaindB.Value;
             //  console.radio.GetDSPRX(1, 1).RXFixedAGC = (double)udDSPAGCRX2FixedGaindB.Value;
 
@@ -10368,7 +10368,7 @@ namespace Thetis
 
         private void udDSPAGCDecay_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // if (udDSPAGCDecay.Enabled)
             {
                 console.radio.GetDSPRX(0, 0).RXAGCDecay = (int)udDSPAGCDecay.Value;
@@ -10378,7 +10378,7 @@ namespace Thetis
 
         private void udDSPAGCRX2Decay_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             //  if (udDSPAGCRX2Decay.Enabled)
             {
                 console.radio.GetDSPRX(1, 0).RXAGCDecay = (int)udDSPAGCRX2Decay.Value;
@@ -10388,21 +10388,21 @@ namespace Thetis
 
         private void udDSPAGCSlope_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXAGCSlope = 10 * (int)(udDSPAGCSlope.Value);
             console.radio.GetDSPRX(0, 1).RXAGCSlope = 10 * (int)(udDSPAGCSlope.Value);
         }
 
         private void udDSPAGCRX2Slope_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXAGCSlope = 10 * (int)(udDSPAGCRX2Slope.Value);
             //    console.radio.GetDSPRX(1, 1).RXAGCSlope = 10 * (int)(udDSPAGCRX2Slope.Value);
         }
 
         private void udDSPAGCHangTime_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // if (udDSPAGCHangTime.Enabled)
             {
                 console.radio.GetDSPRX(0, 0).RXAGCHang = (int)udDSPAGCHangTime.Value;
@@ -10412,7 +10412,7 @@ namespace Thetis
 
         private void udDSPAGCRX2HangTime_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // if (udDSPAGCRX2HangTime.Enabled)
             {
                 console.radio.GetDSPRX(1, 0).RXAGCHang = (int)udDSPAGCRX2HangTime.Value;
@@ -10422,14 +10422,14 @@ namespace Thetis
 
         private void tbDSPAGCHangThreshold_Scroll(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXAGCHangThreshold = (int)tbDSPAGCHangThreshold.Value;
             console.radio.GetDSPRX(0, 1).RXAGCHangThreshold = (int)tbDSPAGCHangThreshold.Value;
         }
 
         private void tbDSPAGCRX2HangThreshold_Scroll(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXAGCHangThreshold = (int)tbDSPAGCRX2HangThreshold.Value;
             //   console.radio.GetDSPRX(1, 1).RXAGCHangThreshold = (int)tbDSPAGCRX2HangThreshold.Value;
         }
@@ -10440,20 +10440,20 @@ namespace Thetis
 
         private void udDSPLevelerThreshold_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXLevelerMaxGain = (double)udDSPLevelerThreshold.Value;
         }
 
         private void udDSPLevelerDecay_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXLevelerDecay = (int)udDSPLevelerDecay.Value;
         }
 
         private bool _oldLevelerState = true; //it is true in frm design
         private void chkDSPLevelerEnabled_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXLevelerOn = chkDSPLevelerEnabled.Checked;
 
             //
@@ -10472,14 +10472,14 @@ namespace Thetis
 
         private void udDSPALCMaximumGain_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             WDSP.SetTXAALCMaxGain(WDSP.id(1, 0), (double)udDSPALCMaximumGain.Value);
             WDSP.ALCGain = (double)udDSPALCMaximumGain.Value;
         }
 
         private void udDSPALCDecay_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXALCDecay = (int)udDSPALCDecay.Value;
         }
 
@@ -10491,7 +10491,8 @@ namespace Thetis
 
         private void udTXFilterHigh_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
+            if (_timerCheckingTXProfile) return;
             if (udTXFilterHigh.Value < udTXFilterLow.Value + 100)
             {
                 udTXFilterHigh.Value = udTXFilterLow.Value + 100;
@@ -10521,7 +10522,8 @@ namespace Thetis
 
         private void udTXFilterLow_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
+            if (_timerCheckingTXProfile) return;
             if (udTXFilterLow.Value > udTXFilterHigh.Value - 100)
             {
                 udTXFilterLow.Value = udTXFilterHigh.Value - 100;
@@ -10540,7 +10542,7 @@ namespace Thetis
 
         private void udTransmitTunePower_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.TunePower = (int)udTXTunePower.Value;
         }
 
@@ -10959,31 +10961,31 @@ namespace Thetis
 
         private void udTXAMCarrierLevel_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXAMCarrierLevel = Math.Sqrt(0.01 * (double)udTXAMCarrierLevel.Value) * 0.5;
         }
 
         private void chkSaveTXProfileOnExit_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.SaveTXProfileOnExit = chkSaveTXProfileOnExit.Checked;
         }
 
         private void udMicGainMin_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MicGainMin = (int)udMicGainMin.Value;
         }
 
         private void udMicGainMax_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MicGainMax = (int)udMicGainMax.Value;
         }
 
         private void udLineInBoost_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.LineInBoost = (double)udLineInBoost.Value;
         }
 
@@ -11383,43 +11385,43 @@ namespace Thetis
 
         private void clrbtnBackground_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.DisplayBackgroundColor = Color.FromArgb(tbBackgroundAlpha.Value, clrbtnBackground.Color);
         }
 
         private void clrbtnTXBackground_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXDisplayBackgroundColor = Color.FromArgb(tbTXBackgroundAlpha.Value, clrbtnTXBackground.Color);
         }
 
         private void clrbtnGrid_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.GridColor = Color.FromArgb(tbGridCourseAlpha.Value, clrbtnGrid.Color);
         }
 
         private void clrbtnTXVGrid_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXVGridColor = Color.FromArgb(tbTXVGridCourseAlpha.Value, clrbtnTXVGrid.Color);
         }
 
         private void clrbtnZeroLine_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.GridZeroColor = clrbtnZeroLine.Color;
         }
 
         private void clrbtnTXZeroLine_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXGridZeroColor = Color.FromArgb(tbTXZeroLineAlpha.Value, clrbtnTXZeroLine.Color);
         }
 
         private void clrbtnText_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.GridTextColor = clrbtnText.Color;
         }
 
@@ -11430,7 +11432,7 @@ namespace Thetis
 
         private void clrbtnDataLine_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             //Display.DataLineColor = clrbtnDataLine.Color;
             Display.DataLineColor = Color.FromArgb(tbDataLineAlpha.Value, clrbtnDataLine.Color); // MW0LGE_21b
             rebuildLGBrushes();
@@ -11445,127 +11447,127 @@ namespace Thetis
         }
         private void clrbtnTXDataLine_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXDataLineColor = clrbtnTXDataLine.Color;
         }
 
         private void clrbtnFilter_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.DisplayFilterColor = Color.FromArgb(tbRX1FilterAlpha.Value, clrbtnFilter.Color);
         }
 
         private void clrbtnGridTXFilter_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXFilterColor = Color.FromArgb(tbTXFilterAlpha.Value, clrbtnGridTXFilter.Color);
         }
 
         private void udDisplayLineWidth_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.DisplayLineWidth = (float)udDisplayLineWidth.Value;
         }
 
         private void udTXLineWidth_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXDisplayLineWidth = (float)udTXLineWidth.Value;
         }
 
         private void clrbtnMeterLeft_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MeterLeftColor = clrbtnMeterLeft.Color;
         }
 
         private void clrbtnMeterRight_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MeterRightColor = clrbtnMeterRight.Color;
         }
 
         private void clrbtnBtnSel_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.ButtonSelectedColor = clrbtnBtnSel.Color;
         }
 
         private void clrbtnVFODark_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.VFOTextDarkColor = clrbtnVFODark.Color;
         }
 
         private void clrbtnVFOLight_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.VFOTextLightColor = clrbtnVFOLight.Color;
         }
 
         private void clrbtnBandDark_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.BandTextDarkColor = clrbtnBandDark.Color;
         }
 
         private void clrbtnBandLight_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.BandTextLightColor = clrbtnBandLight.Color;
         }
 
         private void clrbtnPeakText_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.PeakTextColor = clrbtnPeakText.Color;
         }
 
         private void clrbtnOutOfBand_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.OutOfBandColor = clrbtnOutOfBand.Color;
         }
 
         private void chkVFOSmallLSD_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.SmallLSD = chkVFOSmallLSD.Checked;
         }
 
         private void clrbtnVFOSmallColor_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.SmallVFOColor = clrbtnVFOSmallColor.Color;
         }
 
         private void clrbtnInfoButtonsColor_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.InfoButtonsColor = clrbtnInfoButtonsColor.Color;
         }
 
         private void clrbtnPeakBackground_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.PeakBackgroundColor = clrbtnPeakBackground.Color;
         }
 
         private void clrbtnMeterBackground_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MeterBackgroundColor = clrbtnMeterBackground.Color;
         }
 
         private void clrbtnBandBackground_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.BandBackgroundColor = clrbtnBandBackground.Color;
         }
 
         private void clrbtnVFOBackground_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.VFOBackgroundColor = clrbtnVFOBackground.Color;
         }
 
@@ -11575,73 +11577,73 @@ namespace Thetis
 
         private void comboKBTuneUp1_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneUp1 = (Keys)KeyList[comboKBTuneUp1.SelectedIndex];
         }
 
         private void comboKBTuneDown1_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneDown1 = (Keys)KeyList[comboKBTuneDown1.SelectedIndex];
         }
 
         private void comboKBTuneUp2_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneUp2 = (Keys)KeyList[comboKBTuneUp2.SelectedIndex];
         }
 
         private void comboKBTuneDown2_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneDown2 = (Keys)KeyList[comboKBTuneDown2.SelectedIndex];
         }
 
         private void comboKBTuneUp3_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneUp3 = (Keys)KeyList[comboKBTuneUp3.SelectedIndex];
         }
 
         private void comboKBTuneDown3_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneDown3 = (Keys)KeyList[comboKBTuneDown3.SelectedIndex];
         }
 
         private void comboKBTuneUp4_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneUp4 = (Keys)KeyList[comboKBTuneUp4.SelectedIndex];
         }
 
         private void comboKBTuneDown4_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneDown4 = (Keys)KeyList[comboKBTuneDown4.SelectedIndex];
         }
 
         private void comboKBTuneUp5_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneUp5 = (Keys)KeyList[comboKBTuneUp5.SelectedIndex];
         }
 
         private void comboKBTuneDown5_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneDown5 = (Keys)KeyList[comboKBTuneDown5.SelectedIndex];
         }
 
         private void comboKBTuneUp6_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneUp6 = (Keys)KeyList[comboKBTuneUp6.SelectedIndex];
         }
 
         private void comboKBTuneDown6_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyTuneDown6 = (Keys)KeyList[comboKBTuneDown6.SelectedIndex];
         }
 
@@ -11657,49 +11659,49 @@ namespace Thetis
 
         private void comboKBBandUp_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyBandUp = (Keys)KeyList[comboKBBandUp.SelectedIndex];
         }
 
         private void comboKBBandDown_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyBandDown = (Keys)KeyList[comboKBBandDown.SelectedIndex];
         }
 
         private void comboKBFilterUp_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyFilterUp = (Keys)KeyList[comboKBFilterUp.SelectedIndex];
         }
 
         private void comboKBFilterDown_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyFilterDown = (Keys)KeyList[comboKBFilterDown.SelectedIndex];
         }
 
         private void comboKBModeUp_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyModeUp = (Keys)KeyList[comboKBModeUp.SelectedIndex];
         }
 
         private void comboKBModeDown_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyModeDown = (Keys)KeyList[comboKBModeDown.SelectedIndex];
         }
 
         private void comboKBCWDot_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyCWDot = (Keys)KeyList[comboKBCWDot.SelectedIndex];
         }
 
         private void comboKBCWDash_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyCWDash = (Keys)KeyList[comboKBCWDash.SelectedIndex];
         }
 
@@ -11725,13 +11727,13 @@ namespace Thetis
 
         private void comboKBPTTTx_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyPTTTx = (Keys)KeyList[comboKBPTTTx.SelectedIndex];
         }
 
         private void comboKBPTTRx_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyPTTRx = (Keys)KeyList[comboKBPTTRx.SelectedIndex];
         }
 
@@ -12982,7 +12984,7 @@ namespace Thetis
 
         private void udGeneralLPTDelay_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
         }
 
         private void Setup_Closing(object sender, System.ComponentModel.CancelEventArgs e)
@@ -13600,19 +13602,19 @@ namespace Thetis
 
         private void clrbtnBandEdge_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.BandEdgeColor = clrbtnBandEdge.Color;
         }
 
         private void clrbtnTXBandEdge_Changed(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXBandEdgeColor = clrbtnTXBandEdge.Color;
         }
 
         private void comboMeterType_SelectedIndexChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (comboMeterType.Text == "") return;
             switch (comboMeterType.Text)
             {
@@ -13671,7 +13673,7 @@ namespace Thetis
 
         private void chkCWKeyerMode_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             // if (console.NewProtocol)
             // {
             if (chkCWKeyerMode.Checked)
@@ -13867,7 +13869,7 @@ namespace Thetis
 
         private void udDisplayWaterfallUpdatePeriod_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.WaterfallUpdatePeriod = (int)udDisplayWaterfallUpdatePeriod.Value;
             setWaterFallCalculatedDelayText();
         }
@@ -13882,7 +13884,7 @@ namespace Thetis
 
         private void udRX2DisplayWaterfallUpdatePeriod_ValueChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX2WaterfallUpdatePeriod = (int)udRX2DisplayWaterfallUpdatePeriod.Value;
             setWaterFallCalculatedDelayText();
         }
@@ -13894,14 +13896,14 @@ namespace Thetis
 
         private void chkClickTuneFilter_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.ClickTuneFilter = chkClickTuneFilter.Checked;
             Display.ClickTuneFilter = chkClickTuneFilter.Checked;
         }
 
         private void chkShowCTHLine_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowCTHLine = chkShowCTHLine.Checked;
         }
 
@@ -13987,7 +13989,7 @@ namespace Thetis
 
         private void chkWheelReverse_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.WheelReverse = chkWheelReverse.Checked;
         }
 
@@ -14065,7 +14067,7 @@ namespace Thetis
 
         private void chkCWAutoSwitchMode_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.CWAutoModeSwitch = chkCWAutoSwitchMode.Checked;
             setEnabledAutoModeSwitchCWReturn(chkCWAutoSwitchMode.Checked);
         }
@@ -14166,7 +14168,7 @@ namespace Thetis
 
         private void chkRX2AutoMuteTX_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             //Audio.RX2AutoMuteTX = chkRX2AutoMuteTX.Checked;
             console.MuteRX2OnVFOATX = chkRX2AutoMuteTX.Checked;
         }
@@ -14473,13 +14475,13 @@ namespace Thetis
 
         private void chkAudioRX2toVAC_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VACOutputRX2 = chkAudioRX2toVAC.Checked;
         }
 
         private void chkVAC2UseRX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.VAC2RX2 = chkVAC2UseRX2.Checked;
         }
 
@@ -15174,14 +15176,14 @@ namespace Thetis
 
         private void chkMercDither_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int v = chkMercDither.Checked ? 1 : 0;
             NetworkIO.SetADCDither(v);
         }
 
         private void chkMercRandom_CheckedChanged(object sender, System.EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int v = chkMercRandom.Checked ? 1 : 0;
             NetworkIO.SetADCRandom(v);
         }
@@ -16205,7 +16207,7 @@ namespace Thetis
 
         private void radMicIn_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (!radMicIn.Checked) return;
             console.LineIn = false;
             radLineIn.Checked = false;
@@ -16217,7 +16219,7 @@ namespace Thetis
 
         private void radLineIn_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (!radLineIn.Checked) return;
             console.LineIn = true;
             radMicIn.Checked = false;
@@ -16256,13 +16258,13 @@ namespace Thetis
 
         private void udMoxDelay_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MoxDelay = (int)udMoxDelay.Value;
         }
 
         private void udCWKeyUpDelay_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.KeyUpDelay = (int)udCWKeyUpDelay.Value;
             udCWKeyerSemiBreakInDelay_ValueChanged(this, EventArgs.Empty);
         }
@@ -16274,7 +16276,7 @@ namespace Thetis
 
         private void udTXDisplayCalOffset_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXDisplayCalOffset = (float)udTXDisplayCalOffset.Value;
         }
 
@@ -16285,7 +16287,7 @@ namespace Thetis
 
         private void udTwoToneLevel_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkTestIMD.Checked)
             {
                 Audio.SourceScale = Math.Pow(10.0, (double)udTwoToneLevel.Value / 20.0);
@@ -16294,7 +16296,7 @@ namespace Thetis
 
         private void clrbtnGridFine_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.GridPenDark = Color.FromArgb(tbGridFineAlpha.Value, clrbtnGridFine.Color);
         }
 
@@ -16341,13 +16343,13 @@ namespace Thetis
 
         private void clrbtnHGridColor_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.HGridColor = Color.FromArgb(tbHGridColorAlpha.Value, clrbtnHGridColor.Color);
         }
 
         private void clrbtnTXHGridColor_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.TXHGridColor = Color.FromArgb(tbTXHGridColorAlpha.Value, clrbtnTXHGridColor.Color);
         }
 
@@ -16383,7 +16385,7 @@ namespace Thetis
 
         private void chkGridControl_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.GridControl = chkGridControl.Checked;
         }
 
@@ -17311,49 +17313,49 @@ namespace Thetis
 
         private void chkShowAGC_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.ShowAGC = chkShowAGC.Checked;
         }
 
         private void chkSpectrumLine_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.SpectrumLine = chkSpectrumLine.Checked;
         }
 
         private void chkAGCDisplayHangLine_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.DisplayAGCHangLine = chkAGCDisplayHangLine.Checked;
         }
 
         private void chkAGCHangSpectrumLine_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX1HangSpectrumLine = chkAGCHangSpectrumLine.Checked;
         }
 
         private void chkDisplayRX2GainLine_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.DisplayRX2GainLine = chkDisplayRX2GainLine.Checked;
         }
 
         private void chkRX2GainSpectrumLine_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX2GainSpectrumLine = chkRX2GainSpectrumLine.Checked;
         }
 
         private void chkDisplayRX2HangLine_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.DisplayRX2HangLine = chkDisplayRX2HangLine.Checked;
         }
 
         private void chkRX2HangSpectrumLine_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX2HangSpectrumLine = chkRX2HangSpectrumLine.Checked;
         }
 
@@ -17364,7 +17366,7 @@ namespace Thetis
 
         private void chkFullDiscovery_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkFullDiscovery.Checked) chkEnableStaticIP.Checked = false;
             //    JanusAudio.SetDiscoveryMode(1);
             //else
@@ -17375,7 +17377,7 @@ namespace Thetis
 
         private void chkStrictCharSpacing_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             NetworkIO.EnableCWKeyerSpacing(Convert.ToInt32(chkStrictCharSpacing.Checked));
         }
 
@@ -17544,7 +17546,7 @@ namespace Thetis
 
         private void chkLevelFades_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkLevelFades.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXAMDFadeLevel = 1;
@@ -17559,7 +17561,7 @@ namespace Thetis
 
         private void radLSBUSB_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radLSBUSB.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXAMDSBMode = 0;
@@ -17569,7 +17571,7 @@ namespace Thetis
 
         private void radLSB_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radLSB.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXAMDSBMode = 1;
@@ -17579,7 +17581,7 @@ namespace Thetis
 
         private void radUSB_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radUSB.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXAMDSBMode = 2;
@@ -17589,7 +17591,7 @@ namespace Thetis
 
         private void chkRX2LevelFades_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkRX2LevelFades.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXAMDFadeLevel = 1;
@@ -17604,7 +17606,7 @@ namespace Thetis
 
         private void radRX2LSBUSB_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radRX2LSBUSB.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXAMDSBMode = 0;
@@ -17614,7 +17616,7 @@ namespace Thetis
 
         private void radRX2LSB_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radRX2LSB.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXAMDSBMode = 1;
@@ -17624,7 +17626,7 @@ namespace Thetis
 
         private void radRX2USB_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radRX2USB.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXAMDSBMode = 2;
@@ -18048,7 +18050,7 @@ namespace Thetis
 
         private void tbDisplayFFTSize_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (console._spectrum_mutex != null) console._spectrum_mutex.WaitOne();
 
             console.specRX.GetSpecRX(0).FFTSize = (int)(4096 * Math.Pow(2, Math.Floor((double)(tbDisplayFFTSize.Value))));
@@ -18068,7 +18070,7 @@ namespace Thetis
 
         private void tbRX2DisplayFFTSize_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (console._spectrum_mutex != null) console._spectrum_mutex.WaitOne();
 
             // console.specRX.GetSpecRX(0).FFTSize = (int)(4096 * Math.Pow(2, Math.Floor((double)(tbDisplayFFTSize.Value))));
@@ -18086,7 +18088,7 @@ namespace Thetis
 
         private void comboDispWinType_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(0).WindowType = comboDispWinType.SelectedIndex;
             console.UpdateRXSpectrumDisplayVars();
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).WindowType = comboDispWinType.SelectedIndex;
@@ -18095,34 +18097,34 @@ namespace Thetis
 
         private void comboRX2DispWinType_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(1).WindowType = comboRX2DispWinType.SelectedIndex;
         }
 
         private void udDSPNBTransition_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).NBTau = 0.001 * (double)udDSPNBTransition.Value;
             console.radio.GetDSPRX(1, 0).NBTau = 0.001 * (double)udDSPNBTransition.Value;
         }
 
         private void udDSPNBLead_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).NBAdvTime = 0.001 * (double)udDSPNBLead.Value;
             console.radio.GetDSPRX(1, 0).NBAdvTime = 0.001 * (double)udDSPNBLead.Value;
         }
 
         private void udDSPNBLag_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).NBHangTime = 0.001 * (double)udDSPNBLag.Value;
             console.radio.GetDSPRX(1, 0).NBHangTime = 0.001 * (double)udDSPNBLag.Value;
         }
 
         private void chkCBlock_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkCBlock.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXCBLRun = true;
@@ -18137,7 +18139,7 @@ namespace Thetis
 
         private void chkRX2CBlock_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkRX2CBlock.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXCBLRun = true;
@@ -18174,7 +18176,7 @@ namespace Thetis
 
         private void btnSetIPAddr_Click(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radStaticIP1.Checked)
             {
                 console.HPSDRNetworkIPAddr = udStaticIP1.Text + "." + udStaticIP2.Text + "." +
@@ -18205,7 +18207,7 @@ namespace Thetis
 
         private void chkRX1WaterfallAGC_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX1WaterfallAGC = chkRX1WaterfallAGC.Checked;
             udDisplayWaterfallLowLevel.Enabled = !chkRX1WaterfallAGC.Checked;
             lblWaterfallAGCOffsetRX1.Enabled = chkRX1WaterfallAGC.Checked;
@@ -18215,7 +18217,7 @@ namespace Thetis
 
         private void chkRX2WaterfallAGC_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX2WaterfallAGC = chkRX2WaterfallAGC.Checked;
             udRX2DisplayWaterfallLowLevel.Enabled = !chkRX2WaterfallAGC.Checked;
             lblWaterfallAGCOffsetRX2.Enabled = chkRX2WaterfallAGC.Checked;
@@ -18300,7 +18302,7 @@ namespace Thetis
 
         private void comboDSPRxWindow_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int wintype = comboDSPRxWindow.SelectedIndex;
             if (wintype < 0)
             {
@@ -18316,7 +18318,7 @@ namespace Thetis
 
         private void comboDSPTxWindow_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int wintype = comboDSPTxWindow.SelectedIndex;
             if (wintype < 0)
             {
@@ -18335,13 +18337,13 @@ namespace Thetis
 
         private void radOrionPTTOff_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MicPTTDisabled = radOrionPTTOff.Checked;
         }
 
         private void radOrionMicTip_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radOrionMicTip.Checked)
                 NetworkIO.SetMicTipRing(0);
             else NetworkIO.SetMicTipRing(1);
@@ -18349,7 +18351,7 @@ namespace Thetis
 
         private void radOrionBiasOn_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radOrionBiasOn.Checked)
                 NetworkIO.SetMicBias(1);
             else NetworkIO.SetMicBias(0);
@@ -18381,7 +18383,7 @@ namespace Thetis
 
         private void udTXGenScale_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             switch (cmboSigGenTXMode.Text)
             {
                 case "Tone":
@@ -18407,7 +18409,7 @@ namespace Thetis
 
         private void udTXGenFreq_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             switch (cmboSigGenTXMode.Text)
             {
                 case "Tone":
@@ -18518,13 +18520,13 @@ namespace Thetis
 
         private void chkEmphPos_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXFMEmphOn = !chkEmphPos.Checked;
         }
 
         private void chkRemoveTone_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXFMCTCSSFilter = chkRemoveTone.Checked;
             console.radio.GetDSPRX(0, 1).RXFMCTCSSFilter = chkRemoveTone.Checked;
             console.radio.GetDSPRX(1, 0).RXFMCTCSSFilter = chkRemoveTone.Checked;
@@ -18532,7 +18534,7 @@ namespace Thetis
 
         private void chkFMDetLimON_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXFMDETLIMRUN = chkFMDetLimON.Checked;
             console.radio.GetDSPRX(0, 1).RXFMDETLIMRUN = chkFMDetLimON.Checked;
             console.radio.GetDSPRX(1, 0).RXFMDETLIMRUN = chkFMDetLimON.Checked;
@@ -18540,7 +18542,7 @@ namespace Thetis
 
         private void tbDSPDetLimGain_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXFMDETLIMGAIN = (double)tbDSPFMDetLimGain.Value;
             console.radio.GetDSPRX(0, 1).RXFMDETLIMGAIN = (double)tbDSPFMDetLimGain.Value;
             console.radio.GetDSPRX(1, 0).RXFMDETLIMGAIN = (double)tbDSPFMDetLimGain.Value;
@@ -18548,7 +18550,7 @@ namespace Thetis
 
         private void chkDSPEERon_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkDSPEERon.Checked)
             {
                 console.radio.GetDSPTX(0).TXEERModeRun = true;
@@ -18563,25 +18565,25 @@ namespace Thetis
 
         private void udDSPEERmgain_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXEERModeMgain = (double)udDSPEERmgain.Value;
         }
 
         private void udDSPEERpgain_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXEERModePgain = (double)udDSPEERpgain.Value;
         }
 
         private void udDSPEERmdelay_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXEERModeMdelay = (double)udDSPEERmdelay.Value / 1.0e+06;
         }
 
         private void chkDSPEERamIQ_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXEERModeAMIQ = chkDSPEERamIQ.Checked;
         }
 
@@ -18592,7 +18594,7 @@ namespace Thetis
 
         private void udHWKeyDownDelay_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             NetworkIO.SetCWPTTDelay((int)udHWKeyDownDelay.Value);
         }
 
@@ -18756,7 +18758,7 @@ namespace Thetis
 
         private void radDDCADC_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int val = 0;
 
             //DDC0 ADC control: bits 1 & 0
@@ -18803,7 +18805,7 @@ namespace Thetis
 
         private void radP1DDCADC_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int val = 0;
 
             //protocol 1 DDC0 ADC control: bits 1 & 0
@@ -18844,7 +18846,7 @@ namespace Thetis
 
         private void comboDSPNOBmode_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int nbmode = comboDSPNOBmode.SelectedIndex;
             if (nbmode < 0)
             {
@@ -18868,7 +18870,7 @@ namespace Thetis
 
         private void chkDSPRX1APFEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (console.RX1DSPMode == DSPMode.CWL ||
                 console.RX1DSPMode == DSPMode.CWU)
                 console.radio.GetDSPRX(0, 0).RXAPFRun = chkDSPRX1APFEnable.Checked;
@@ -18887,7 +18889,7 @@ namespace Thetis
 
         private void chkDSPRX1subAPFEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (console.RX1DSPMode == DSPMode.CWL ||
                 console.RX1DSPMode == DSPMode.CWU)
                 console.radio.GetDSPRX(0, 1).RXAPFRun = chkDSPRX1subAPFEnable.Checked;
@@ -18907,7 +18909,7 @@ namespace Thetis
 
         private void chkDSPRX2APFEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (console.RX2DSPMode == DSPMode.CWL ||
                  console.RX2DSPMode == DSPMode.CWU)
                 console.radio.GetDSPRX(1, 0).RXAPFRun = chkDSPRX2APFEnable.Checked;
@@ -18922,7 +18924,7 @@ namespace Thetis
 
         private void tbDSPAudRX1APFGain_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXAPFGain = Math.Pow(10.0, (double)tbDSPAudRX1APFGain.Value / 200.0);
             if (radDSPRX1APFControls.Checked)
                 console.APFGain = tbDSPAudRX1APFGain.Value;
@@ -18930,7 +18932,7 @@ namespace Thetis
 
         private void tbDSPAudRX1subAPFGain_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 1).RXAPFGain = Math.Pow(10.0, (double)tbDSPAudRX1subAPFGain.Value / 200.0);
             if (radDSPRX1subAPFControls.Checked)
                 console.APFGain = tbDSPAudRX1subAPFGain.Value;
@@ -18938,7 +18940,7 @@ namespace Thetis
 
         private void tbDSPAudRX2APFGain_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXAPFGain = Math.Pow(10.0, (double)tbDSPAudRX2APFGain.Value / 200.0);
             if (radDSPRX2APFControls.Checked)
                 console.APFGain = tbDSPAudRX2APFGain.Value;
@@ -18946,7 +18948,7 @@ namespace Thetis
 
         private void tbRX1APFTune_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXAPFFreq = console.CWPitch + (double)tbRX1APFTune.Value;
             if (radDSPRX1APFControls.Checked)
                 console.APFFreq = tbRX1APFTune.Value;
@@ -18954,7 +18956,7 @@ namespace Thetis
 
         private void tbRX1subAPFTune_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 1).RXAPFFreq = console.CWPitch + (double)tbRX1subAPFTune.Value;
             if (radDSPRX1subAPFControls.Checked)
                 console.APFFreq = tbRX1subAPFTune.Value;
@@ -18962,7 +18964,7 @@ namespace Thetis
 
         private void tbRX2APFTune_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXAPFFreq = console.CWPitch + (double)tbRX2APFTune.Value;
             if (radDSPRX2APFControls.Checked)
                 console.APFFreq = tbRX2APFTune.Value;
@@ -18970,7 +18972,7 @@ namespace Thetis
 
         private void tbRX1APFBW_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXAPFBw = (double)tbRX1APFBW.Value;
             if (radDSPRX1APFControls.Checked)
                 console.APFBandwidth = tbRX1APFBW.Value;
@@ -18978,7 +18980,7 @@ namespace Thetis
 
         private void tbRX1subAPFBW_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 1).RXAPFBw = (double)tbRX1subAPFBW.Value;
             if (radDSPRX1subAPFControls.Checked)
                 console.APFBandwidth = tbRX1subAPFBW.Value;
@@ -18986,7 +18988,7 @@ namespace Thetis
 
         private void tbRX2APFBW_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXAPFBw = (double)tbRX2APFBW.Value;
             if (radDSPRX2APFControls.Checked)
                 console.APFBandwidth = tbRX2APFBW.Value;
@@ -18994,7 +18996,7 @@ namespace Thetis
 
         private void radDSPRX1APFControls_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPRX1APFControls.Checked)
             {
                 chkDSPRX1APFEnable.Checked = console.APFEnabled;
@@ -19013,7 +19015,7 @@ namespace Thetis
 
         private void radDSPRX1subAPFControls_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPRX1subAPFControls.Checked)
             {
                 chkDSPRX1subAPFEnable.Checked = console.APFEnabled;
@@ -19032,7 +19034,7 @@ namespace Thetis
 
         private void radDSPRX2APFControls_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPRX2APFControls.Checked)
             {
                 chkDSPRX2APFEnable.Checked = console.APFEnabled;
@@ -19051,55 +19053,55 @@ namespace Thetis
 
         private void chkDSPRX1DollyEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXADollyRun = chkDSPRX1DollyEnable.Checked;
         }
 
         private void chkDSPRX1DollySubEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 1).RXADollyRun = chkDSPRX1SubDollyEnable.Checked;
         }
 
         private void chkDSPRX2DollyEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXADollyRun = chkDSPRX2DollyEnable.Checked;
         }
 
         private void udDSPRX1DollyF0_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXADollyFreq0 = (double)udDSPRX1DollyF0.Value;
         }
 
         private void udDSPRX1SubDollyF0_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 1).RXADollyFreq0 = (double)udDSPRX1SubDollyF0.Value;
         }
 
         private void udDSPRX2DollyF0_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXADollyFreq0 = (double)udDSPRX2DollyF0.Value;
         }
 
         private void udDSPRX1DollyF1_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXADollyFreq1 = (double)udDSPRX1DollyF1.Value;
         }
 
         private void udDSPRX2DollyF1_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(1, 0).RXADollyFreq1 = (double)udDSPRX2DollyF1.Value;
         }
 
         private void udDSPRX1SubDollyF1_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 1).RXADollyFreq1 = (double)udDSPRX1SubDollyF1.Value;
         }
         private bool _updatingATTTX = false;
@@ -19118,25 +19120,25 @@ namespace Thetis
 
         private void udDSPEERpdelay_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXEERModePdelay = (double)udDSPEERpdelay.Value / 1.0e+06;
         }
 
         private void chkDSPEERRunDelays_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPTX(0).TXEERModeRunDelays = chkDSPEERRunDelays.Checked;
         }
 
         private void udDSPEERpwmMax_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             NetworkIO.SetEERPWMmax((int)udDSPEERpwmMax.Value);
         }
 
         private void udDSPEERpwmMin_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             NetworkIO.SetEERPWMmin((int)udDSPEERpwmMin.Value);
         }
 
@@ -19200,7 +19202,7 @@ namespace Thetis
 
         private void chkDSPCESSB_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.TxOsctrl = chkDSPCESSB.Checked;
             if (chkDSPCESSB.Checked)
             {
@@ -19215,7 +19217,7 @@ namespace Thetis
 
         private void udRXAMSQMaxTail_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.radio.GetDSPRX(0, 0).RXAMSquelchMaxTail = (double)udRXAMSQMaxTail.Value;
             console.radio.GetDSPRX(0, 1).RXAMSquelchMaxTail = (double)udRXAMSQMaxTail.Value;
             console.radio.GetDSPRX(1, 0).RXAMSquelchMaxTail = (double)udRXAMSQMaxTail.Value;
@@ -19224,7 +19226,7 @@ namespace Thetis
 
         private void radDSPNR2Linear_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPNR2Linear.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXANR2GainMethod = 0;
@@ -19234,7 +19236,7 @@ namespace Thetis
 
         private void radDSPNR2Log_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPNR2Log.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXANR2GainMethod = 1;
@@ -19244,7 +19246,7 @@ namespace Thetis
 
         private void radDSPNR2OSMS_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPNR2OSMS.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXANR2NPEMethod = 0;
@@ -19254,7 +19256,7 @@ namespace Thetis
 
         private void radDSPNR2MMSE_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPNR2MMSE.Checked)
             {
                 console.radio.GetDSPRX(0, 0).RXANR2NPEMethod = 1;
@@ -19264,7 +19266,7 @@ namespace Thetis
 
         private void chkDSPNR2AE_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int run;
             if (chkDSPNR2AE.Checked)
                 run = 1;
@@ -19276,7 +19278,7 @@ namespace Thetis
 
         private void radDSPNR2LinearRX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPNR2LinearRX2.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXANR2GainMethod = 0;
@@ -19286,7 +19288,7 @@ namespace Thetis
 
         private void radDSPNR2LogRX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPNR2LogRX2.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXANR2GainMethod = 1;
@@ -19296,7 +19298,7 @@ namespace Thetis
 
         private void radDSPNR2OSMSRX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPNR2OSMSRX2.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXANR2NPEMethod = 0;
@@ -19306,7 +19308,7 @@ namespace Thetis
 
         private void radDSPNR2MMSERX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (radDSPNR2MMSERX2.Checked)
             {
                 console.radio.GetDSPRX(1, 0).RXANR2NPEMethod = 1;
@@ -19316,7 +19318,7 @@ namespace Thetis
 
         private void chkDSPNR2AERX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int run;
             if (chkDSPNR2AERX2.Checked)
                 run = 1;
@@ -19340,7 +19342,7 @@ namespace Thetis
 
         private void chkLimitExtAmpOnOverload_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.AmpProtect = chkLimitExtAmpOnOverload.Checked;
             if (chkLimitExtAmpOnOverload.Checked)
                 cmaster.SetAmpProtectRun(0, 1);
@@ -19350,7 +19352,7 @@ namespace Thetis
 
         private void comboFocusMasterMode_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             switch (comboFocusMasterMode.Text)
             {
                 case "N1MM+ Logger":
@@ -19476,7 +19478,7 @@ namespace Thetis
 
         private void udDSPSNBThresh1_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             WDSP.SetRXASNBAk1(WDSP.id(0, 0), (double)udDSPSNBThresh1.Value);
             WDSP.SetRXASNBAk1(WDSP.id(0, 1), (double)udDSPSNBThresh1.Value);
             WDSP.SetRXASNBAk1(WDSP.id(2, 0), (double)udDSPSNBThresh1.Value);
@@ -19484,7 +19486,7 @@ namespace Thetis
 
         private void udDSPSNBThresh2_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             WDSP.SetRXASNBAk2(WDSP.id(0, 0), (double)udDSPSNBThresh2.Value);
             WDSP.SetRXASNBAk2(WDSP.id(0, 1), (double)udDSPSNBThresh2.Value);
             WDSP.SetRXASNBAk2(WDSP.id(2, 0), (double)udDSPSNBThresh2.Value);
@@ -19754,7 +19756,7 @@ namespace Thetis
 
         private void chkMNFAutoIncrease_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             WDSP.RXANBPSetAutoIncrease(WDSP.id(0, 0), chkMNFAutoIncrease.Checked);
             WDSP.RXANBPSetAutoIncrease(WDSP.id(0, 1), chkMNFAutoIncrease.Checked);
             WDSP.RXANBPSetAutoIncrease(WDSP.id(2, 0), chkMNFAutoIncrease.Checked);
@@ -19853,55 +19855,55 @@ namespace Thetis
 
         private void chkNetworkWDT_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             NetworkIO.SetWatchdogTimer(Convert.ToInt32(chkNetworkWDT.Checked));
         }
 
         private void comboRX2DispPanDetector_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(1).DetTypePan = comboRX2DispPanDetector.SelectedIndex;
         }
 
         private void comboRX2DispPanAveraging_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(1).AverageMode = comboRX2DispPanAveraging.SelectedIndex;
         }
 
         private void comboRX2DispWFDetector_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(1).DetTypeWF = comboRX2DispWFDetector.SelectedIndex;
         }
 
         private void comboRX2DispWFAveraging_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(1).AverageModeWF = comboRX2DispWFAveraging.SelectedIndex;
         }
 
         private void udRX2DisplayWFAVTime_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(1).AvTauWF = 0.001 * (double)udRX2DisplayWFAVTime.Value;
         }
 
         private void comboDispPanDetector_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(0).DetTypePan = comboDispPanDetector.SelectedIndex;
         }
 
         private void comboDispWFDetector_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(0).DetTypeWF = comboDispWFDetector.SelectedIndex;
         }
 
         private void comboDispPanAveraging_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(0).AverageMode = comboDispPanAveraging.SelectedIndex;
             console.UpdateRXSpectrumDisplayVars();
             console.UpdateTXSpectrumDisplayVars();
@@ -19909,52 +19911,52 @@ namespace Thetis
 
         private void comboDispWFAveraging_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(0).AverageModeWF = comboDispWFAveraging.SelectedIndex;
         }
 
         private void udDisplayAVTimeWF_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(0).AvTauWF = 0.001 * (double)udDisplayAVTimeWF.Value;
         }
 
         private void chkDispRX2Normalize_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(1).NormOneHzPan = chkDispRX2Normalize.Checked;
         }
 
         private void chkDispNormalize_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(0).NormOneHzPan = chkDispNormalize.Checked;
         }
 
         private void comboTXDispPanDetector_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).DetTypePan = comboTXDispPanDetector.SelectedIndex;
             console.UpdateTXSpectrumDisplayVars();
         }
 
         private void comboTXDispPanAveraging_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).AverageMode = comboTXDispPanAveraging.SelectedIndex;
             console.UpdateTXSpectrumDisplayVars();
         }
 
         private void udTXDisplayAVGTime_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).AvTau = 0.001 * (double)udTXDisplayAVGTime.Value;
             console.UpdateTXSpectrumDisplayVars();
         }
 
         private void chkDispTXNormalize_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).NormOneHzPan = chkDispTXNormalize.Checked;
             console.UpdateTXSpectrumDisplayVars();
         }
@@ -19969,35 +19971,35 @@ namespace Thetis
 
         private void comboTXDispWinType_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).WindowType = comboTXDispWinType.SelectedIndex;
             console.UpdateTXSpectrumDisplayVars();
         }
 
         private void comboTXDispWFDetector_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).DetTypeWF = comboTXDispWFDetector.SelectedIndex;
             console.UpdateTXSpectrumDisplayVars();
         }
 
         private void comboTXDispWFAveraging_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).AverageModeWF = comboTXDispWFAveraging.SelectedIndex;
             console.UpdateTXSpectrumDisplayVars();
         }
 
         private void udTXDisplayAVTime_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.specRX.GetSpecRX(cmaster.inid(1, 0)).AvTauWF = 0.001 * (double)udTXDisplayAVTime.Value;
             console.UpdateTXSpectrumDisplayVars();
         }
 
         private void chkBPF2Gnd_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.BPF2Gnd = chkBPF2Gnd.Checked;
         }
 
@@ -20133,7 +20135,7 @@ namespace Thetis
 
         private void chkANAN8000DLEDisplayVoltsAmps_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.ANAN8000DLEDisplayVoltsAmps = chkANAN8000DLEDisplayVoltsAmps.Checked;
         }
 
@@ -20144,14 +20146,14 @@ namespace Thetis
 
         private void chkEnableXVTRHF_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.EnableXVTRHF = chkEnableXVTRHF.Checked;
         }
 
         private bool _oldCFCState = false; // is false in frm design
         private void chkCFCEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int run;
             if (chkCFCEnable.Checked) run = 1;
             else run = 0;
@@ -20169,7 +20171,7 @@ namespace Thetis
 
         private void setCFCProfile(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             const int nfreqs = 10;
             double[] F = new double[nfreqs];
             double[] G = new double[nfreqs];
@@ -20219,7 +20221,7 @@ namespace Thetis
 
         private void tbCFCPRECOMP_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             WDSP.SetTXACFCOMPPrecomp(WDSP.id(1, 0), (double)tbCFCPRECOMP.Value);
 
             setDBtip(sender);
@@ -20229,7 +20231,7 @@ namespace Thetis
 
         private void chkCFCPeqEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int run;
             if (chkCFCPeqEnable.Checked) run = 1;
             else run = 0;
@@ -20241,7 +20243,7 @@ namespace Thetis
 
         private void chkPHROTEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int run;
             if (chkPHROTEnable.Checked) run = 1;
             else run = 0;
@@ -20250,19 +20252,19 @@ namespace Thetis
 
         private void udPhRotFreq_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             WDSP.SetTXAPHROTCorner(WDSP.id(1, 0), (double)udPhRotFreq.Value);
         }
 
         private void udPHROTStages_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             WDSP.SetTXAPHROTNstages(WDSP.id(1, 0), (int)udPHROTStages.Value);
         }
 
         private void tbCFCPEG_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             WDSP.SetTXACFCOMPPrePeq(WDSP.id(1, 0), (double)tbCFCPEQGAIN.Value);
 
             setDBtip(sender);
@@ -20339,7 +20341,7 @@ namespace Thetis
 
         private void radTXDSB_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int value = 0;
             if (radTXDSB.Checked)
                 value = 0;
@@ -20554,7 +20556,7 @@ namespace Thetis
 
         private void chkVAC1_Force_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool force = chkVAC1_Force.Checked;
             double fvar = (double)udVAC1_Force.Value;
             ivac.forceIVACvar(0, 0, force, fvar);
@@ -20562,7 +20564,7 @@ namespace Thetis
 
         private void chkVAC1_Force2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool force = chkVAC1_Force2.Checked;
             double fvar = (double)udVAC1_Force2.Value;
             ivac.forceIVACvar(0, 1, force, fvar);
@@ -20693,7 +20695,7 @@ namespace Thetis
 
         private void chkVAC2onSplit_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.VAC2onSplit = chkVAC2onSplit.Checked;
         }
 
@@ -20701,7 +20703,7 @@ namespace Thetis
 
         private void chkVOXEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VOXEnabled = chkVOXEnable.Checked;
             console.VOXEnable = chkVOXEnable.Checked;
             chkDEXPLookAheadEnable_CheckedChanged(this, EventArgs.Empty);
@@ -20709,7 +20711,7 @@ namespace Thetis
 
         private void chkDEXPEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPRun(0, chkDEXPEnable.Checked);
             console.NoiseGateEnabled = chkDEXPEnable.Checked;
             chkDEXPLookAheadEnable_CheckedChanged(this, EventArgs.Empty);
@@ -20717,75 +20719,75 @@ namespace Thetis
 
         private void udDEXPAttack_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPAttackTime(0, (double)udDEXPAttack.Value / 1000.0);
         }
 
         private void udDEXPHold_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPHoldTime(0, (double)udDEXPHold.Value / 1000.0);
         }
 
         private void udDEXPRelease_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPReleaseTime(0, (double)udDEXPRelease.Value / 1000.0);
         }
 
         private void udDEXPThreshold_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.CMSetTXAVoxThresh(0, Math.Pow(10.0, (double)udDEXPThreshold.Value / 20.0));
             console.VOXSens = (int)udDEXPThreshold.Value;
         }
 
         private void udDEXPExpansionRatio_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPExpansionRatio(0, Math.Pow(10.0, (double)udDEXPExpansionRatio.Value / 20.0));
         }
 
         private void udDEXPHysteresisRatio_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPHysteresisRatio(0, Math.Pow(10.0, -(double)udDEXPHysteresisRatio.Value / 20.0));
         }
 
         private void udDEXPDetTau_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPDetectorTau(0, (double)udDEXPDetTau.Value / 1000.0);
         }
 
         private void chkSCFEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPRunSideChannelFilter(0, chkSCFEnable.Checked);
         }
 
         private void udSCFLowCut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPLowCut(0, (double)udSCFLowCut.Value);
         }
 
         private void udSCFHighCut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPHighCut(0, (double)udSCFHighCut.Value);
         }
 
         private void chkDEXPLookAheadEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool enable = chkDEXPLookAheadEnable.Checked && (chkVOXEnable.Checked || chkDEXPEnable.Checked);
             cmaster.SetDEXPRunAudioDelay(0, enable);
         }
 
         private void udDEXPLookAhead_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetDEXPAudioDelay(0, (double)udDEXPLookAhead.Value / 1000.0);
         }
 
@@ -20807,25 +20809,25 @@ namespace Thetis
 
         private void chkAntiVoxEnable_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetAntiVOXRun(0, chkAntiVoxEnable.Checked);
         }
 
         private void udAntiVoxGain_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetAntiVOXGain(0, Math.Pow(10.0, (double)udAntiVoxGain.Value / 20.0));
         }
 
         private void udAntiVoxTau_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             cmaster.SetAntiVOXDetectorTau(0, (double)udAntiVoxTau.Value / 1000.0);
         }
 
         private void chkAntiVoxSource_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.AntiVOXSourceVAC = chkAntiVoxSource.Checked;
         }
 
@@ -20845,7 +20847,7 @@ namespace Thetis
 
         private void clrbtnDataFill_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.DataFillColor = Color.FromArgb(tbDataFillAlpha.Value, clrbtnDataFill.Color);
         }
 
@@ -20902,7 +20904,7 @@ namespace Thetis
 
         private void ChkAlsoUseSpecificMouseWheel_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.AlsoUseSpecificMouseWheel = chkAlsoUseSpecificMouseWheel.Checked;
             setupHIDControls(console.AlsoUseSpecificMouseWheel);
         }
@@ -20998,7 +21000,7 @@ namespace Thetis
 
         private void chkShowRXFilterOnWaterfall_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowRXFilterOnWaterfall = chkShowRXFilterOnWaterfall.Checked;
         }
 
@@ -21009,7 +21011,7 @@ namespace Thetis
 
         private void chkShowRXZeroLineOnWaterfall_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowRXZeroLineOnWaterfall = chkShowRXZeroLineOnWaterfall.Checked;
         }
 
@@ -21020,7 +21022,7 @@ namespace Thetis
 
         private void chkShowTXFilterOnRXWaterfall_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowTXFilterOnRXWaterfall = chkShowTXFilterOnRXWaterfall.Checked;
         }
 
@@ -21098,7 +21100,7 @@ namespace Thetis
 
         private void chkRecenterOnZZFx_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.CATChangesCenterFreq = chkRecenterOnZZFx.Checked;
         }
 
@@ -21172,7 +21174,7 @@ namespace Thetis
 
         private void chkAccurateFrameTiming_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.UseAccurateFramingTiming = chkAccurateFrameTiming.Checked;
         }
 
@@ -21196,7 +21198,7 @@ namespace Thetis
         }
         private void chkPeakBlobsEnabled_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool bEnabled = chkPeakBlobsEnabled.Checked;
             udPeakBlobs.Enabled = bEnabled;
             chkPeakBlobInsideFilterOnly.Enabled = bEnabled;
@@ -21215,19 +21217,19 @@ namespace Thetis
 
         private void udPeakBlobs_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.NumberOfPeakBlobs = (int)udPeakBlobs.Value;
         }
 
         private void chkPeakBlobInsideFilterOnly_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowPeakBlobsInsideFilterOnly = chkPeakBlobInsideFilterOnly.Checked;
         }
 
         private void chkSignalHistory_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.UseSignalHistory = chkSignalHistory.Checked;
             udSignalHistoryDuration.Enabled = chkSignalHistory.Checked;
             lblSignalHistoryDurationMS.Enabled = chkSignalHistory.Checked;
@@ -21235,7 +21237,7 @@ namespace Thetis
 
         private void clrbtnSignalHistoryColour_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.SignalHistoryColour = Color.FromArgb(tbSignalHistoryAlpha.Value, clrbtnSignalHistoryColour.Color);
         }
 
@@ -21247,7 +21249,7 @@ namespace Thetis
 
         private void chkVSyncDX_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkVSyncDX.Checked)
             {
                 Display.VerticalBlanks = 1;
@@ -21260,7 +21262,7 @@ namespace Thetis
 
         private void chkBlobPeakHold_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             chkPeakHoldDrop.Enabled = chkBlobPeakHold.Checked && chkBlobPeakHold.Enabled;
             udBlobPeakHoldMS.Enabled = chkBlobPeakHold.Checked && chkBlobPeakHold.Enabled;
 
@@ -21269,13 +21271,13 @@ namespace Thetis
 
         private void udBlobPeakHoldMS_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.BlobPeakHoldMS = (double)udBlobPeakHoldMS.Value;
         }
 
         private void udSignalHistoryDuration_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.SignalHistoryDuration = (int)udSignalHistoryDuration.Value;
         }
 
@@ -21286,7 +21288,7 @@ namespace Thetis
 
         private void chkBypassVACPlayingRecording_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.BypassVACWhenPlayingRecording = chkBypassVACPlayingRecording.Checked;
         }
 
@@ -21506,7 +21508,7 @@ namespace Thetis
 
         private void chkQSOTimerEnabled_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool bEnabled = chkQSOTimerEnabled.Checked;
 
             chkQSOTimerOnlyDuringMOX.Enabled = bEnabled;
@@ -21528,13 +21530,13 @@ namespace Thetis
 
         private void chkQSOTimerOnlyDuringMOX_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.QSOTimerDuringMoxOnly = chkQSOTimerOnlyDuringMOX.Checked;
         }
 
         private void chkQSOTimerPlaySoundOnExpiry_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool bEnabled = chkQSOTimerEnabled.Checked && chkQSOTimerPlaySoundOnExpiry.Checked;
 
             btnQSOTimerSelectWAV.Enabled = bEnabled;
@@ -21569,25 +21571,25 @@ namespace Thetis
 
         private void udQSOTimerMinutes_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             setQSOTimerDuration();
         }
 
         private void udQSOTimerSeconds_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             setQSOTimerDuration();
         }
 
         private void chkQSOTimerResetOnMOX_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.QSOTimerResetOnMox = chkQSOTimerResetOnMOX.Checked;
         }
 
         private void setQSOTimerDuration()
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int nDurationSecs = ((int)udQSOTimerMinutes.Value * 60) + (int)udQSOTimerSeconds.Value;
             if (nDurationSecs < 5)
             {
@@ -21601,7 +21603,7 @@ namespace Thetis
 
         private void chkQSOTimerResetOnExpiry_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.QSOTimerResetOnExpiry = chkQSOTimerResetOnExpiry.Checked;
 
             chkQSOTimerFlashTimerIfResetOnExpiry.Enabled = chkQSOTimerResetOnExpiry.Enabled && chkQSOTimerResetOnExpiry.Checked;
@@ -21611,7 +21613,7 @@ namespace Thetis
 
         private void chkQSOTimerFlashTimerIfResetOnExpiry_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.QSOTimerFlashAfterAutoReset = chkQSOTimerFlashTimerIfResetOnExpiry.Checked;
         }
 
@@ -22443,7 +22445,7 @@ namespace Thetis
 
         private void chkRadioProtocolSelect_CheckStateChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             switch (chkRadioProtocolSelect.CheckState)
             {
                 case CheckState.Checked:
@@ -22553,7 +22555,7 @@ namespace Thetis
 
         private void chkActivePeakHoldRX1_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             lblActivePeakHoldRX1.Enabled = chkActivePeakHoldRX1.Checked;
             udActivePeakHoldDurationRX1.Enabled = chkActivePeakHoldRX1.Checked;
             lblActivePeakHoldDropRX1.Enabled = chkActivePeakHoldRX1.Checked;
@@ -22567,13 +22569,13 @@ namespace Thetis
 
         private void udActivePeakHoldDurationRX1_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.SpectralPeakHoldDelayRX1 = (double)udActivePeakHoldDurationRX1.Value;
         }
 
         private void chkActivePeakHoldRX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             lblActivePeakHoldRX1.Enabled = chkActivePeakHoldRX2.Checked;
             udActivePeakHoldDurationRX2.Enabled = chkActivePeakHoldRX2.Checked;
             lblActivePeakHoldDropRX2.Enabled = chkActivePeakHoldRX2.Checked;
@@ -22587,13 +22589,13 @@ namespace Thetis
 
         private void udActivePeakHoldDurationRX2_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.SpectralPeakHoldDelayRX2 = (double)udActivePeakHoldDurationRX2.Value;
         }
 
         private void clrbtnActiveSpectralPeak_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.DataPeaksFillColor = Color.FromArgb(tbActiveSpectralPeakAlpha.Value, clrbtnActiveSpectralPeak.Color);
         }
 
@@ -22641,7 +22643,7 @@ namespace Thetis
 
         private void chkPanadpatorGradient_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             lgLinearGradientRX1.Enabled = chkPanadpatorGradient.Checked;
             btnClearColourGrippers.Enabled = chkPanadpatorGradient.Checked;
             btnDeleteColourGripper.Enabled = chkPanadpatorGradient.Checked;
@@ -22662,13 +22664,13 @@ namespace Thetis
 
         private void chkSpecWarningLEDRenderDelay_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowFrameRateIssue = chkSpecWarningLEDRenderDelay.Checked;
         }
 
         private void chkSpecWarningLEDGetPixels_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowGetPixelsIssue = chkSpecWarningLEDGetPixels.Checked;
         }
 
@@ -22687,7 +22689,7 @@ namespace Thetis
 
         private void chkPeakHoldDrop_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             lblPeakBlobDropDBMs.Enabled = chkPeakHoldDrop.Checked;
             udPeakBlobDropDBMs.Enabled = chkPeakHoldDrop.Checked;
 
@@ -22817,45 +22819,45 @@ namespace Thetis
 
         private void txtN1MMSendTo_TextChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             N1MM.DestinationIP = txtN1MMSendTo.Text;
         }
 
         private void udN1MMSendRate_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             N1MM.SendRate = (int)udN1MMSendRate.Value;
         }
 
         private void udN1MMRX1Scaling_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             N1MM.SetScale(1, (float)udN1MMRX1Scaling.Value);
         }
 
         private void udN1MMRX2Scaling_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             N1MM.SetScale(2, (float)udN1MMRX2Scaling.Value);
         }
 
         private void tbRX1WaterfallOpacity_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX1WaterfallOpacity = tbRX1WaterfallOpacity.Value / 100f;
             toolTip1.SetToolTip(tbRX1WaterfallOpacity, tbRX1WaterfallOpacity.Value.ToString() + "% opacity");
         }
 
         private void tbRX2WaterfallOpacity_Scroll(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.RX2WaterfallOpacity = tbRX2WaterfallOpacity.Value / 100f;
             toolTip1.SetToolTip(tbRX2WaterfallOpacity, tbRX2WaterfallOpacity.Value.ToString() + "% opacity");
         }
 
         private void chkShowControlDebug_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (chkShowControlDebug.Checked) chkShowDisplayDebug.Checked = false;
 
             console.EnableControlDebug = chkShowControlDebug.Checked;
@@ -23223,24 +23225,24 @@ namespace Thetis
 
         private void udVAC1FeedbackGainIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1FeedbackGainIn = (double)udVAC1FeedbackGainIn.Value;
         }
 
         private void udVAC1SlewTimeIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1SlewTimeIn = (double)udVAC1SlewTimeIn.Value;
         }
         private void udVAC1FeedbackGainOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1FeedbackGainOut = (double)udVAC1FeedbackGainOut.Value;
         }
 
         private void udVAC1SlewTimeOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1SlewTimeOut = (double)udVAC1SlewTimeOut.Value;
         }
 
@@ -23261,24 +23263,24 @@ namespace Thetis
 
         private void udVAC2FeedbackGainIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2FeedbackGainIn = (double)udVAC2FeedbackGainIn.Value;
         }
 
         private void udVAC2SlewTimeIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2SlewTimeIn = (double)udVAC2SlewTimeIn.Value;
         }
         private void udVAC2FeedbackGainOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2FeedbackGainOut = (double)udVAC2FeedbackGainOut.Value;
         }
 
         private void udVAC2SlewTimeOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2SlewTimeOut = (double)udVAC2SlewTimeOut.Value;
         }
         private void pbVAC1FeedbackGainInfo_Click(object sender, EventArgs e)
@@ -23345,7 +23347,7 @@ namespace Thetis
 
         private void clrbtnBandstackOverlay_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.BandstackOverlayColor = Color.FromArgb(tbBandstackOverlayAlpha.Value, clrbtnBandstackOverlay.Color);
         }
 
@@ -23398,13 +23400,13 @@ namespace Thetis
 
         private void udVAC1PropMinIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1PropRingMinIn = (int)udVAC1PropMinIn.Value;
         }
 
         private void udVAC1PropMaxIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int tmp = (int)udVAC1PropMaxIn.Value;
             int old = Audio.VAC1PropRingMaxIn;
 
@@ -23430,13 +23432,13 @@ namespace Thetis
 
         private void udVAC1FFMinIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1FFRingMinIn = (int)udVAC1FFMinIn.Value;
         }
 
         private void udVAC1FFMaxIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int tmp = (int)udVAC1FFMaxIn.Value;
             int old = Audio.VAC1FFRingMaxIn;
 
@@ -23462,25 +23464,25 @@ namespace Thetis
 
         private void udVAC1FFAlphaIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1FFAlphaIn = (double)udVAC1FFAlphaIn.Value;
         }
 
         private void chkVAC1OldVarIn_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             txtVAC1OldVarIn_TextChanged(this, EventArgs.Empty);
         }
 
         private void udVAC1PropMinOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1PropRingMinOut = (int)udVAC1PropMinOut.Value;
         }
 
         private void udVAC1PropMaxOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int tmp = (int)udVAC1PropMaxOut.Value;
             int old = Audio.VAC1PropRingMaxOut;
 
@@ -23506,13 +23508,13 @@ namespace Thetis
 
         private void udVAC1FFMinOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1FFRingMinOut = (int)udVAC1FFMinOut.Value;
         }
 
         private void udVAC1FFMaxOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int tmp = (int)udVAC1FFMaxOut.Value;
             int old = Audio.VAC1FFRingMaxOut;
 
@@ -23538,39 +23540,39 @@ namespace Thetis
 
         private void udVAC1FFAlphaOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC1FFAlphaOut = (double)udVAC1FFAlphaOut.Value;
         }
 
         private void chkVAC1OldVarOut_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             txtVAC1OldVarOut_TextChanged(this, EventArgs.Empty);
         }
 
         private void txtVAC1OldVarIn_TextChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool bOk = double.TryParse(txtVAC1OldVarIn.Text, out double tmp);
             Audio.VAC1OldVarIn = bOk && chkVAC1OldVarIn.Checked ? tmp : 1.0;
         }
 
         private void txtVAC1OldVarOut_TextChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool bOk = double.TryParse(txtVAC1OldVarOut.Text, out double tmp);
             Audio.VAC1OldVarOut = bOk && chkVAC1OldVarOut.Checked ? tmp : 1.0;
         }
 
         private void udVAC2PropMinIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2PropRingMinIn = (int)udVAC2PropMinIn.Value;
         }
 
         private void udVAC2PropMaxIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int tmp = (int)udVAC2PropMaxIn.Value;
             int old = Audio.VAC2PropRingMaxIn;
 
@@ -23596,13 +23598,13 @@ namespace Thetis
 
         private void udVAC2FFMinIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2FFRingMinIn = (int)udVAC2FFMinIn.Value;
         }
 
         private void udVAC2FFMaxIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int tmp = (int)udVAC2FFMaxIn.Value;
             int old = Audio.VAC2FFRingMaxIn;
 
@@ -23628,25 +23630,25 @@ namespace Thetis
 
         private void udVAC2FFAlphaIn_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2FFAlphaIn = (double)udVAC2FFAlphaIn.Value;
         }
 
         private void chkVAC2OldVarIn_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             txtVAC2OldVarIn_TextChanged(this, EventArgs.Empty);
         }
 
         private void udVAC2PropMinOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2PropRingMinOut = (int)udVAC2PropMinOut.Value;
         }
 
         private void udVAC2PropMaxOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int tmp = (int)udVAC2PropMaxOut.Value;
             int old = Audio.VAC2PropRingMaxOut;
 
@@ -23672,13 +23674,13 @@ namespace Thetis
 
         private void udVAC2FFMinOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2FFRingMinOut = (int)udVAC2FFMinOut.Value;
         }
 
         private void udVAC2FFMaxOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             int tmp = (int)udVAC2FFMaxOut.Value;
             int old = Audio.VAC2FFRingMaxOut;
 
@@ -23704,26 +23706,26 @@ namespace Thetis
 
         private void udVAC2FFAlphaOut_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Audio.VAC2FFAlphaOut = (double)udVAC2FFAlphaOut.Value;
         }
 
         private void chkVAC2OldVarOut_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             txtVAC2OldVarOut_TextChanged(this, EventArgs.Empty);
         }
 
         private void txtVAC2OldVarIn_TextChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool bOk = double.TryParse(txtVAC2OldVarIn.Text, out double tmp);
             Audio.VAC2OldVarIn = bOk && chkVAC2OldVarIn.Checked ? tmp : 1.0;
         }
 
         private void txtVAC2OldVarOut_TextChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             bool bOk = double.TryParse(txtVAC2OldVarOut.Text, out double tmp);
             Audio.VAC2OldVarOut = bOk && chkVAC2OldVarOut.Checked ? tmp : 1.0;
         }
@@ -23902,25 +23904,25 @@ namespace Thetis
 
         private void chkTuneStepPerModeRX1_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.TuneStepPerModeRX1 = chkTuneStepPerModeRX1.Checked;
         }
 
         private void chkVAC1WillMute_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MuteWillMuteVAC1 = chkVAC1WillMute.Checked;
         }
 
         private void chkVAC2WillMute_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.MuteWillMuteVAC2 = chkVAC2WillMute.Checked;
         }
 
         private void chkAllowHotSwitching_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.AllowHotSwitchingForOCTXPins = chkAllowHotSwitching.Checked;
         }
 
@@ -23952,25 +23954,25 @@ namespace Thetis
 
         private void chkShowRX1NoiseFloor_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowRX1NoiseFloor = chkShowRX1NoiseFloor.Checked;
         }
 
         private void chkShowRX2NoiseFloor_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowRX2NoiseFloor = chkShowRX2NoiseFloor.Checked;
         }
 
         private void chkAutoAGCRX1_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.AutoAGCRX1 = chkAutoAGCRX1.Checked;
         }
 
         private void chkAutoAGCRX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.AutoAGCRX2 = chkAutoAGCRX2.Checked;
         }
 
@@ -23992,13 +23994,13 @@ namespace Thetis
         }
         private void udRX1AutoAGCOffset_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.AutoAGCOffsetRX1 = (double)udRX1AutoAGCOffset.Value;
         }
 
         private void udRX2AutoAGCOffset_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.AutoAGCOffsetRX2 = (double)udRX2AutoAGCOffset.Value;
         }
 
@@ -24049,55 +24051,55 @@ namespace Thetis
 
         private void udNoiseFloorAttackRX1_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.AttackTimeInMSForRX1 = (float)udNoiseFloorAttackRX1.Value;
         }
 
         private void udNoiseFloorAttackRX2_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.AttackTimeInMSForRX2 = (float)udNoiseFloorAttackRX2.Value;
         }
 
         private void clrbtnNoiseFloor_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.NoiseFloorColor = clrbtnNoiseFloor.Color;
         }
 
         private void chkNoiseFloorShowDBM_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowNoiseFloorDBM = chkNoiseFloorShowDBM.Checked;
         }
 
         private void udNoiseFloorLineWidth_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.NoiseFloorLineWidth = (float)udNoiseFloorLineWidth.Value;
         }
 
         private void udWaterfallAGCOffsetRX1_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.WaterfallAGCOffsetRX1 = (float)udWaterfallAGCOffsetRX1.Value;
         }
 
         private void chkWaterfallUseNFForAGCRX1_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.WaterfallUseNFForACGRX1 = chkWaterfallUseNFForAGCRX1.Checked;
         }
 
         private void udWaterfallAGCOffsetRX2_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.WaterfallAGCOffsetRX2 = (float)udWaterfallAGCOffsetRX2.Value;
         }
 
         private void chkWaterfallUseNFForAGCRX2_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.WaterfallUseNFForACGRX2 = chkWaterfallUseNFForAGCRX2.Checked;
         }
 
@@ -24259,7 +24261,7 @@ namespace Thetis
 
         private void udCFCPicDBPerLine_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             udCFCPicDBPerLine.Value = (int)(udCFCPicDBPerLine.Value / 10) * 10;
             picCFC.Invalidate();
         }
@@ -24428,7 +24430,7 @@ namespace Thetis
 
         private void chkCTUNignore0beat_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.CTUNputsZeroOnMouse = !chkCTUNignore0beat.Checked;
         }
 
@@ -24541,19 +24543,19 @@ namespace Thetis
 
         private void udMaxTCISpots_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             SpotManager2.MaxNumber = (int)udMaxTCISpots.Value;
         }
 
         private void udTCISpotLifetime_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             SpotManager2.LifeTime = (int)udTCISpotLifetime.Value;
         }
 
         private void chkShowTCISpots_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             Display.ShowTCISpots = chkShowTCISpots.Checked;
 
             //
@@ -24579,7 +24581,7 @@ namespace Thetis
 
         private void chkSpotOwnCallAppearance_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             txtOwnCallsign.Enabled = chkSpotOwnCallAppearance.Checked;
             clrbtnOwnCallApearance.Enabled = chkSpotOwnCallAppearance.Checked;
 
@@ -24731,7 +24733,7 @@ namespace Thetis
 
         private void chkUsing10MHzRef_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             btnGeneralCalFreqStart.Enabled = !chkUsing10MHzRef.Checked;
             udHPSDRFreqCorrectFactor10MHz.Enabled = chkUsing10MHzRef.Checked;
 
@@ -24863,12 +24865,12 @@ namespace Thetis
 
         private void udTestIMDPower_ValueChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.TwoToneTunePower = (int)udTestIMDPower.Value;
         }
         private void setupTuneAnd2ToneRadios()
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             switch (console.TuneDrivePowerOrigin)
             {
                 case DrivePowerSource.DRIVE_SLIDER:
@@ -26473,7 +26475,7 @@ namespace Thetis
 
         private void clrbtnSliderLimitBar_Changed(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.LimitSliderColor = clrbtnSliderLimitBar.Color;
         }
 
@@ -26564,7 +26566,7 @@ namespace Thetis
 
         private void chkForceATTwhenPSAoff_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             console.ForceATTwhenPSAoff = chkForceATTwhenPSAoff.Checked;
         }
 
@@ -27821,7 +27823,7 @@ namespace Thetis
 
         private void chkConsoleDarkModeTitleBar_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             if (console != null)
             {
                 bool bOk = Common.UseImmersiveDarkMode(console.Handle, chkConsoleDarkModeTitleBar.Checked);
@@ -27898,13 +27900,17 @@ namespace Thetis
         }
         #endregion
 
+        private bool _timerCheckingTXProfile = false; //[2.10.3.5]MW0LGE used to bypass changed events caused
+                                                      //by checkTXProfileChanged2() in tmrCheckProfile_Tick() reading values fix #301
         private void tmrCheckProfile_Tick(object sender, EventArgs e)
         {
             if (!this.Visible || _savingOptions || _gettingOptions) return;
 
             tmrCheckProfile.Enabled = false;
 
+            _timerCheckingTXProfile = true;
             bool bChanged = checkTXProfileChanged2();
+            _timerCheckingTXProfile = false;
 
             lblTXProfileWarning.Visible = bChanged;
 
@@ -28079,7 +28085,7 @@ namespace Thetis
 
         private void chkAutoModeSwitchCWReturn_CheckedChanged(object sender, EventArgs e)
         {
-            if (initializing) return; //[2.10.2.3]MW0LGE forceallevents call this
+            if (initializing) return;
             nudAutoModeSwitchCWReturn.Enabled = chkAutoModeSwitchCWReturn.Checked;
             lblAutoModeSwitchCWms.Enabled = chkAutoModeSwitchCWReturn.Checked;
 


### PR DESCRIPTION
- bypass change events when tx profile checker is running via timer
- remove bunch of pointless comments