### PR TITLE
Adding fix for 'Investigate power (CW) appearing on rx only ports #228'

### DIFF
--- a/Project Files/Source/ChannelMaster/netInterface.c
+++ b/Project Files/Source/ChannelMaster/netInterface.c
@@ -439,6 +439,10 @@ void SetAntBits(int rx_only_ant, int trx_ant, int tx_ant, int rx_out, char tx) {
 	prbpfilter->_ANT_2 = (trx_ant & (0x01 | 0x02)) == 0x02;
 	prbpfilter->_ANT_3 = (trx_ant & (0x01 | 0x02)) == (0x01 | 0x02);
 
+	// copy the upper 16 bits of Alex0
+	prbpfilter2->bpfilter = prbpfilter->bpfilter & 0xf8ff0000;
+
+	// then set the TX mode ANT 1-3 bits
 	prbpfilter2->_TXANT_1 = (tx_ant & (0x01 | 0x02)) == 0x01;
 	prbpfilter2->_TXANT_2 = (tx_ant & (0x01 | 0x02)) == 0x02;
 	prbpfilter2->_TXANT_3 = (tx_ant & (0x01 | 0x02)) == (0x01 | 0x02);

--- a/Project Files/Source/ChannelMaster/netInterface.c
+++ b/Project Files/Source/ChannelMaster/netInterface.c
@@ -411,7 +411,7 @@ void SetADCRandom(int bits)
 }
 
 PORT
-void SetAntBits(int rx_only_ant, int trx_ant, int rx_out, char tx) {
+void SetAntBits(int rx_only_ant, int trx_ant, int tx_ant, int rx_out, char tx) {
 
 	if (mkiibpf)
 	{
@@ -438,6 +438,11 @@ void SetAntBits(int rx_only_ant, int trx_ant, int rx_out, char tx) {
 	prbpfilter->_ANT_1 = (trx_ant & (0x01 | 0x02)) == 0x01;
 	prbpfilter->_ANT_2 = (trx_ant & (0x01 | 0x02)) == 0x02;
 	prbpfilter->_ANT_3 = (trx_ant & (0x01 | 0x02)) == (0x01 | 0x02);
+
+	prbpfilter2->_TXANT_1 = (tx_ant & (0x01 | 0x02)) == 0x01;
+	prbpfilter2->_TXANT_2 = (tx_ant & (0x01 | 0x02)) == 0x02;
+	prbpfilter2->_TXANT_3 = (tx_ant & (0x01 | 0x02)) == (0x01 | 0x02);
+
 	if (listenSock != INVALID_SOCKET && prn->sendHighPriority != 0)
 		CmdHighPriority();
 }

--- a/Project Files/Source/ChannelMaster/network.c
+++ b/Project Files/Source/ChannelMaster/network.c
@@ -802,6 +802,8 @@ void CmdHighPriority() { // port 1027
 		prn->rx[0].preamp;
 
 	// Alex1 data 
+	packetbuf[1428] = (prbpfilter2->bpfilter >> 24) & 0xff; // [31:24] TXANT
+	packetbuf[1429] = (prbpfilter2->bpfilter >> 16) & 0xff; // [23:16] TXANT
 	packetbuf[1430] = (prbpfilter2->bpfilter >> 8) & 0xff; //RX1
 	packetbuf[1431] = prbpfilter2->bpfilter & 0xff; //RX1
 

--- a/Project Files/Source/ChannelMaster/network.h
+++ b/Project Files/Source/ChannelMaster/network.h
@@ -307,23 +307,41 @@ typedef struct _rbpfilter2 // radio band pass filter
 	{
 		unsigned bpfilter;
 		struct {
-			unsigned char  _rx_yellow_led : 1, // bit 
-			               _13MHz_HPF     : 1, // bit 
-			               _20MHz_HPF     : 1, // bit 
-			               _6M_preamp     : 1, // bit 
-			               _9_5MHz_HPF    : 1, // bit 
-			               _6_5MHz_HPF    : 1, // bit 
-			               _1_5MHz_HPF    : 1, // bit 
-			                              : 1, // bit 
+			unsigned char  _rx_yellow_led : 1, // bit 00
+			               _13MHz_HPF     : 1, // bit 01
+			               _20MHz_HPF     : 1, // bit 02
+			               _6M_preamp     : 1, // bit 03
+			               _9_5MHz_HPF    : 1, // bit 04
+			               _6_5MHz_HPF    : 1, // bit 05
+			               _1_5MHz_HPF    : 1, // bit 06
+			                              : 1, // bit 07
 
-			               _rx2_gnd       : 1, // bit 		
-			                              : 1, // bit 	
-			                              : 1, // bit 
-			                              : 1, // bit 
-			               _Bypass        : 1, // bit 
-			                              : 1, // bit 
-			                              : 1, // bit 
-			               _rx_red_led    : 1; // bit 
+			               _rx2_gnd       : 1, // bit 08	
+			                              : 1, // bit 09
+			                              : 1, // bit 10
+			                              : 1, // bit 11
+			               _Bypass        : 1, // bit 12
+			                              : 1, // bit 13
+			                              : 1, // bit 14
+			               _rx_red_led    : 1, // bit 15
+
+			                              : 1, // bit 16
+			                              : 1, // bit 17
+			               _trx_status    : 1, // bit 18
+			               _tx_yellow_led : 1, // bit 19
+			               _30_20_LPF     : 1, // bit 20
+			               _60_40_LPF     : 1, // bit 21
+			               _80_LPF        : 1, // bit 22
+			               _160_LPF       : 1, // bit 23
+
+			               _TXANT_1       : 1, // bit 24
+			               _TXANT_2       : 1, // bit 25
+			               _TXANT_3       : 1, // bit 26
+			               _TR_Relay      : 1, // bit 27
+			               _tx_red_led    : 1, // bit 28
+			               _6_LPF         : 1, // bit 29
+			               _12_10_LPF     : 1, // bit 30
+			               _17_15_LPF     : 1; // bit 31
 		};
 	};
 }rbpfilter2, *RBPFILTER2;

--- a/Project Files/Source/Console/HPSDR/Alex.cs
+++ b/Project Files/Source/Console/HPSDR/Alex.cs
@@ -245,6 +245,7 @@ namespace Thetis
 
 		private int m_nOld_rx_only_ant = -99;
 		private int m_nOld_trx_ant = -99;
+		private int m_nOld_tx_ant = -99;
 		private int m_nOld_rx_out = -99;
 		private bool m_bOld_tx = false;
 
@@ -252,12 +253,13 @@ namespace Thetis
 		{
 			if ( !alex_enabled ) 
 			{ 
-				NetworkIO.SetAntBits(0, 0, 0, false); 
+				NetworkIO.SetAntBits(0, 0, 0, 0, false); 
 				return;
 			}            
 
 			int rx_only_ant; 
 			int trx_ant; 
+			int tx_ant; 
 			int rx_out;
             int xrx_out;
 
@@ -275,6 +277,8 @@ namespace Thetis
 			} 
 
 			//System.Console.WriteLine("Ant idx: " + idx);  //moved into different check down below			
+
+			tx_ant = TxAnt[idx];
 
 			if ( tx ) 
 			{
@@ -337,16 +341,18 @@ namespace Thetis
 			//MW0LGE_21k9d only set bits if different
 			if (m_nOld_rx_only_ant != rx_only_ant ||
 				m_nOld_trx_ant != trx_ant ||
+				m_nOld_tx_ant != tx_ant ||
 				m_nOld_rx_out != rx_out ||
 				m_bOld_tx != tx)
 			{
                 System.Console.WriteLine("Ant idx: " + idx); //MW0LGE [2.9.0.8] moved here
-                NetworkIO.SetAntBits(rx_only_ant, trx_ant, rx_out, tx);
-				System.Console.WriteLine("Ant Rx Only {0} , Tx Ant {1}, Rx Out {2}, TX {3}", rx_only_ant.ToString(), trx_ant.ToString(), rx_out.ToString(), tx.ToString());
+                NetworkIO.SetAntBits(rx_only_ant, trx_ant, tx_ant, rx_out, tx);
+				System.Console.WriteLine("Ant Rx Only {0} , TRx Ant {1}, Tx Ant {2}, Rx Out {3}, TX {4}", rx_only_ant.ToString(), trx_ant.ToString(), tx_ant.ToString(), rx_out.ToString(), tx.ToString());
 
 				//store old
 				m_nOld_rx_only_ant = rx_only_ant;
 				m_nOld_trx_ant = trx_ant;
+				m_nOld_tx_ant = tx_ant;
 				m_nOld_rx_out = rx_out;
 				m_bOld_tx = tx;
 			}

--- a/Project Files/Source/Console/HPSDR/NetworkIOImports.cs
+++ b/Project Files/Source/Console/HPSDR/NetworkIOImports.cs
@@ -315,7 +315,7 @@ namespace Thetis
         public static extern void SetOCBits(int b);
 
         [DllImport("ChannelMaster.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void SetAntBits(int rx_ant, int tx_ant, int rx_out, bool tx);
+        public static extern void SetAntBits(int rx_ant, int trx_ant, int tx_ant, int rx_out, bool tx);
 
         [DllImport("ChannelMaster.dll", CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetMKIIBPF(int bpf);


### PR DESCRIPTION
this adds sending the selected ANT1-3 bits through the High Priority Packet. New SDR firmware will use this to decide which ANT to select BEFORE going into TX. Older SDR firmware will still operate the same selecting the ANT after going to TX.