### PR TITLE
zzxa and related midi

### DIFF
--- a/Project Files/Source/Console/CAT/CATCommands.cs
+++ b/Project Files/Source/Console/CAT/CATCommands.cs
@@ -8162,6 +8162,25 @@ namespace Thetis
                 return parser.Error1;
             }
         }
+
+        public string ZZXA(string s)
+        {
+            if (console is null) return parser.Error1;
+
+            if (s.Length == parser.nSet && (s == "0" || s == "1"))
+            {
+                console.EnableAudioAmplifier = (s == "1");
+                return "";
+            }
+            else if (s.Length == parser.nGet)
+            {
+                return console.EnableAudioAmplifier ? "1" : "0";
+            }
+            else
+            {
+                return parser.Error1;
+            }
+        }
         #endregion Extended CAT Methods ZZR-ZZZ
 
 

--- a/Project Files/Source/Console/CAT/CATParser.cs
+++ b/Project Files/Source/Console/CAT/CATParser.cs
@@ -1491,6 +1491,9 @@ namespace Thetis
                 case "ZZZO":
                     rtncmd = cmdlist.ZZZO(suffix);
                     break;
+                case "ZZXA":
+                    rtncmd = cmdlist.ZZXA(suffix);
+                    break;
             }
             if (!rtncmd.Contains(Error1))
             //rtncmd != Error1 && rtncmd != Error2 && rtncmd != Error3)

--- a/Project Files/Source/Console/CAT/CATStructs.xml
+++ b/Project Files/Source/Console/CAT/CATStructs.xml
@@ -2864,5 +2864,12 @@
 		<nsetparms>1</nsetparms>
 		<ngetparms>0</ngetparms>
 		<nansparms>1</nansparms>		
+	</catstruct>
+	<catstruct code="ZZXA">
+		<desc>Audio Amp</desc>
+		<active>true</active>
+		<nsetparms>1</nsetparms>
+		<ngetparms>0</ngetparms>
+		<nansparms>1</nansparms>
 	</catstruct>	
 </catstructs>

--- a/Project Files/Source/Console/Midi2CatCommands.cs
+++ b/Project Files/Source/Console/Midi2CatCommands.cs
@@ -6315,6 +6315,28 @@ namespace Thetis
             }
             return CmdState.NoChange;
         }
+        public CmdState AudioAmpOnOff(int msg, MidiDevice device)
+        {
+            if (msg == 127)
+            {
+                parser.nGet = 0;
+                parser.nSet = 1;
+
+                int audioAmpEnabled = Convert.ToInt16(commands.ZZXA(""));
+
+                if (audioAmpEnabled == 0)
+                {
+                    commands.ZZXA("1");
+                    return CmdState.On;
+                }
+                if (audioAmpEnabled == 1)
+                {
+                    commands.ZZXA("0");
+                    return CmdState.Off;
+                }
+            }
+            return CmdState.NoChange;
+        }
         #endregion
     }
 }

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -26384,7 +26384,7 @@ namespace Thetis
                 if (m_bAttontx) NetworkIO.SetTxAttenData(getTXstepAttenuatorForBand(tx_band)); //[2.10.3.6]MW0LGE att_fixes
                 else NetworkIO.SetTxAttenData(0);
 
-                enableAudioAmplfier(_bEnableAudioAmplifier); // MW0LGE_22b
+                enableAudioAmplfier(); // MW0LGE_22b
 
                 if (!Audio.Start())   // starts JanusAudio running
                 {
@@ -46776,12 +46776,14 @@ namespace Thetis
             set
             {
                 _bEnableAudioAmplifier = value;
-                enableAudioAmplfier(_bEnableAudioAmplifier);
+                if (!IsSetupFormNull)
+                    SetupForm.DisableAudioAmplifier = !_bEnableAudioAmplifier;
+                enableAudioAmplfier();
             }
         }
-        private void enableAudioAmplfier(bool bEnable)
+        private void enableAudioAmplfier()
         {
-            if (NetworkIO.CurrentRadioProtocol == RadioProtocol.ETH &&
+            if (NetworkIO.CurrentRadioProtocol == RadioProtocol.ETH && //only protocol 2
                 (CurrentHPSDRModel == HPSDRModel.ANAN7000D || CurrentHPSDRModel == HPSDRModel.ANAN8000D
                 || CurrentHPSDRModel == HPSDRModel.ANAN_G2 || current_hpsdr_model == HPSDRModel.ANAN_G2_1K))
             {

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -21839,7 +21839,14 @@ namespace Thetis
         {
             console.EmulateExpertSDR3Protocol = chkEmulateExpertSDR3Protocol.Checked;
         }
-
+        public bool DisableAudioAmplifier
+        {
+            set
+            {
+                if(chkDisableRearSpeakerJacksAudioAmplifier.Checked != value)
+                    chkDisableRearSpeakerJacksAudioAmplifier.Checked = value;
+            }
+        }
         private void chkDisableRearSpeakerJacksAudioAmplifier_CheckedChanged(object sender, EventArgs e)
         {
             console.EnableAudioAmplifier = !chkDisableRearSpeakerJacksAudioAmplifier.Checked;

--- a/Project Files/Source/Midi2Cat/Midi2Cat.Data/CatCmdDb.cs
+++ b/Project Files/Source/Midi2Cat/Midi2Cat.Data/CatCmdDb.cs
@@ -505,6 +505,8 @@ namespace Midi2Cat.Data
         QuickPlayOnOff = 306,
         [CatCommandAttribute("Quick Rec Wave File", ControlType.Button, true)] // DH1KLM
         QuickRecOnOff = 307,
+        [CatCommandAttribute("Audio Amp On Off", ControlType.Button, true)] // [2.10.3.6]MW0LGE 
+        AudioAmpOnOff = 308,
         [CatCommandAttribute("Toggle Wheel to VFOA/VFOB ", ControlType.Button)]  //-W2PA Added a toggle between A/B for main wheel 
         ToggleVFOWheel = 700
     }

--- a/Project Files/Source/ReleaseNotes.txt
+++ b/Project Files/Source/ReleaseNotes.txt
@@ -9,8 +9,10 @@ Please report any issue over on [GitHub here](https://github.com/ramdor/Thetis/i
 - [add] option in setup for S9 @ -73 or -93 for 30MHz and 144MHz (github #418)
 - [add] options added for SWR protection. Swr limits, and tune power (github #221)
 - [add] zzoa and zzoc cat commands have been added. zzoa - get/set the rx antenna based on rx1 band. zzoc - get/set the tx antenna based on tx band (github #385)
-- [add] rx antenna port selection option for XVTR. It should also revert any changes if you leave an xvtr band. Only applies to RX1 currently
-- [add] 8 diversity memories. shift click to store, ctrl click to clear
+- [add] rx antenna port selection option for XVTR. It should also revert any changes if you leave an xvtr band. Only applies to RX1 currently (github #424)
+- [add] 8 diversity memories. shift click to store, ctrl click to clear (github #263)
+- [add] zzxa cat command to get/set audio amplifier (rear speaker sockets). zzxa1; to enable, zzxa0; to disable (github #308)
+- [add] midi button command to toggle audio amplifier (rear speaker sockets) (github #308)
 - [fix] decouple of the rx1/rx2 attenuator preamp/s-att boxes from tx-att. New tx-att control, and bg colour settings in appearance (github #399)
 - [change] simplification improvements to db import
 


### PR DESCRIPTION
- [add] zzxa cat command to get/set audio amplifier (rear speaker sockets). zzxa1; to enable, zzxa0; to disable (github #308)
- [add] midi button command to toggle audio amplifier (rear speaker sockets) (github #308)