### PR TITLE
mm fixes for zero state

### DIFF
--- a/Project Files/Source/Console/MeterManager.cs
+++ b/Project Files/Source/Console/MeterManager.cs
@@ -947,6 +947,7 @@ namespace Thetis
         {
             _rx1VHForAbove = _console.VFOAFreq >= _console.S9Frequency;
             _rx2VHForAbove = _console.RX2Enabled && _console.VFOBFreq >= _console.S9Frequency;
+            zeroAllMeters();
         }
         public static void RefreshAllImages()
         {
@@ -3473,7 +3474,18 @@ namespace Thetis
                 if (_scaleCalibration != null || _scaleCalibration.Count > 0)
                 {
                     value = _scaleCalibration.OrderBy(p => p.Key).First().Key;
-                    if (IsAboveS9Frequency(rx)) value -= 20;
+                    switch (ReadingSource)
+                    {
+                        case Reading.SIGNAL_STRENGTH:
+                        case Reading.AVG_SIGNAL_STRENGTH:
+                            {
+                                if (IsAboveS9Frequency(rx))
+                                    value = -153; //S0
+                                else
+                                    value = -133; //S0
+                            }
+                            break;
+                    }
                     return true;
                 }
                 value = 0;
@@ -4020,7 +4032,99 @@ namespace Thetis
                 if (_scaleCalibration != null || _scaleCalibration.Count > 0)
                 {
                     value = _scaleCalibration.OrderBy(p => p.Key).First().Key;
-                    if (IsAboveS9Frequency(rx)) value -= 20;
+                    switch (ReadingSource)
+                    {
+                        case Reading.SIGNAL_STRENGTH:
+                        case Reading.AVG_SIGNAL_STRENGTH:
+                            {
+                                if (IsAboveS9Frequency(rx))
+                                    value = -153; //S0
+                                else
+                                    value = -133; //S0
+                            }
+                            break;
+                        case Reading.ADC_PK:
+                        case Reading.ADC_AV:
+                            {
+                                value = -120.0f;
+                            }
+                            break;
+                        case Reading.AGC_AV:
+                        case Reading.AGC_PK:
+                            value = -125.0f;
+                            break;
+                        case Reading.AGC_GAIN:
+                            {
+                                value = -50.0f;
+                            }
+                            break;
+                        case Reading.MIC:
+                        case Reading.MIC_PK:
+                            {
+                                value = -120.0f;
+                            }
+                            break;
+                        case Reading.LEVELER:
+                        case Reading.LEVELER_PK:
+                            {
+                                value = -30.0f;
+                            }
+                            break;
+                        case Reading.LVL_G:
+                            {
+                                value = 0f;
+                            }
+                            break;
+                        case Reading.ALC:
+                        case Reading.ALC_PK:
+                            {
+                                value = -120.0f;
+                            }
+                            break;
+                        case Reading.ALC_G: //alc comp
+                            {
+                                value = 0f;
+                            }
+                            break;
+                        case Reading.ALC_GROUP:
+                            {
+                                value = -30.0f;
+                            }
+                            break;
+                        case Reading.CFC_AV:
+                        case Reading.CFC_PK:
+                            {
+                                value = -30.0f;
+                            }
+                            break;
+                        case Reading.CFC_G:
+                            {
+                                value = 0f;
+                            }
+                            break;
+                        case Reading.COMP:
+                        case Reading.COMP_PK:
+                            {
+                                value = -30.0f;
+                            }
+                            break;
+                        case Reading.PWR:
+                        case Reading.REVERSE_PWR:
+                            {
+                                value = 0f;
+                            }
+                            break;
+                        case Reading.SWR:
+                            {
+                                value = 1.0f;
+                            }
+                            break;
+                        case Reading.ESTIMATED_PBSNR:
+                            {
+                                value = 0f;
+                            }
+                            break;
+                    }                    
                     return true;
                 }
                 value = 0;
@@ -4283,11 +4387,21 @@ namespace Thetis
             }
             public override bool ZeroOut(out float value, int rx)
             {
-                if (IsAboveS9Frequency(rx))
-                    value = -153; //S0
-                else
-                    value = -133; //S0
-                return true;
+                switch (ReadingSource)
+                {
+                    case Reading.SIGNAL_STRENGTH:
+                    case Reading.AVG_SIGNAL_STRENGTH:
+                        {
+                            if (IsAboveS9Frequency(rx))
+                                value = -153; //S0
+                            else
+                                value = -133; //S0
+                            return true;
+                        }
+                        break;
+                }
+                value = 0;
+                return false;
             }
         }
         internal class clsNeedleItem : clsMeterItem
@@ -4545,7 +4659,50 @@ namespace Thetis
                 if(_scaleCalibration != null || _scaleCalibration.Count > 0)
                 {
                     value = _scaleCalibration.OrderBy(p => p.Key).First().Key;
-                    if (IsAboveS9Frequency(rx)) value -= 20;
+                    switch (ReadingSource)
+                    {
+                        case Reading.SIGNAL_STRENGTH:
+                        case Reading.AVG_SIGNAL_STRENGTH:
+                            {
+                                if (IsAboveS9Frequency(rx))
+                                    value = -153; //S0
+                                else
+                                    value = -133; //S0
+
+                            }
+                            break;
+                        case Reading.PWR:
+                        case Reading.REVERSE_PWR:
+                            {
+                                value = 0f;
+                            }
+                            break;
+                        case Reading.VOLTS:
+                            {
+                                value = 10f;
+                            }
+                            break;
+                        case Reading.AMPS:
+                            {
+                                value = 10f;
+                            }
+                            break;
+                        case Reading.SWR:
+                            {
+                                value = 1.0f;
+                            }
+                            break;
+                        case Reading.ALC_G: //alc comp
+                            {
+                                value = 0f;
+                            }
+                            break;
+                        case Reading.ALC_GROUP:
+                            {
+                                value = -30.0f;
+                            }
+                            break;
+                    }
                     return true;
                 }
                 value = 0;
@@ -7016,11 +7173,13 @@ namespace Thetis
 
                         if (bOk)
                         {
-                            //[2.10.1.0] MW0LGE only want to do this if value is lower than current reading
+                            // //[2.10.1.0] MW0LGE only want to do this if value is lower than current reading
                             float reading = getReading(RX, mi.ReadingSource);
-                            bool bUpdate = (value < reading) || (reading == -200f); // -220f is init or no value state
-                            if (bRxReadings && bUpdate) setReadingForced(RX, mi.ReadingSource, value);
-                            if (bTxReadings && bUpdate) setReadingForced(RX, mi.ReadingSource, value);
+                            //bool bUpdate = (value < reading) || (reading == -200f); // -200f is init or no value state
+                            //if (bUpdate)
+                            //{
+                                if(bRxReadings || bTxReadings) setReadingForced(RX, mi.ReadingSource, value);
+                            //}
                         }
                     }
                 }

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -3032,6 +3032,7 @@
             this.comboMeterType = new System.Windows.Forms.ComboBoxTS();
             this.tpAppearanceMeter2 = new System.Windows.Forms.TabPage();
             this.grpMultiMeterHolder = new System.Windows.Forms.GroupBoxTS();
+            this.lblMMContainerNotes = new System.Windows.Forms.LabelTS();
             this.txtContainerNotes = new System.Windows.Forms.TextBoxTS();
             this.chkContainerEnable = new System.Windows.Forms.CheckBoxTS();
             this.chkContainerNoTitle = new System.Windows.Forms.CheckBoxTS();
@@ -3577,7 +3578,6 @@
             this.panelTS4 = new System.Windows.Forms.PanelTS();
             this.radioButtonTS5 = new System.Windows.Forms.RadioButtonTS();
             this.radioButtonTS6 = new System.Windows.Forms.RadioButtonTS();
-            this.lblMMContainerNotes = new System.Windows.Forms.LabelTS();
             tpAlexAntCtrl = new System.Windows.Forms.TabPage();
             numericUpDownTS3 = new System.Windows.Forms.NumericUpDownTS();
             numericUpDownTS4 = new System.Windows.Forms.NumericUpDownTS();
@@ -49206,6 +49206,17 @@
             this.grpMultiMeterHolder.TabIndex = 86;
             this.grpMultiMeterHolder.TabStop = false;
             // 
+            // lblMMContainerNotes
+            // 
+            this.lblMMContainerNotes.AutoSize = true;
+            this.lblMMContainerNotes.Image = null;
+            this.lblMMContainerNotes.Location = new System.Drawing.Point(163, 67);
+            this.lblMMContainerNotes.Name = "lblMMContainerNotes";
+            this.lblMMContainerNotes.Size = new System.Drawing.Size(38, 13);
+            this.lblMMContainerNotes.TabIndex = 107;
+            this.lblMMContainerNotes.Text = "Notes:";
+            this.lblMMContainerNotes.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
             // txtContainerNotes
             // 
             this.txtContainerNotes.Location = new System.Drawing.Point(166, 83);
@@ -50239,7 +50250,7 @@
             0,
             0});
             this.nudMeterItemUpdateRate.Minimum = new decimal(new int[] {
-            30,
+            15,
             0,
             0,
             0});
@@ -57078,17 +57089,6 @@
             this.radioButtonTS6.TabStop = true;
             this.radioButtonTS6.Text = "Auto";
             this.radioButtonTS6.UseVisualStyleBackColor = true;
-            // 
-            // lblMMContainerNotes
-            // 
-            this.lblMMContainerNotes.AutoSize = true;
-            this.lblMMContainerNotes.Image = null;
-            this.lblMMContainerNotes.Location = new System.Drawing.Point(163, 67);
-            this.lblMMContainerNotes.Name = "lblMMContainerNotes";
-            this.lblMMContainerNotes.Size = new System.Drawing.Size(38, 13);
-            this.lblMMContainerNotes.TabIndex = 107;
-            this.lblMMContainerNotes.Text = "Notes:";
-            this.lblMMContainerNotes.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // Setup
             // 


### PR DESCRIPTION
fixes for multimeters where initial/zeroed values would be incorrect, such as -195mic, and -19:0swr