### PR TITLE
Add independent processed TX audio output while preserving VAC2

### DIFF
--- a/Project Files/Source/ChannelMaster/cmaster.c
+++ b/Project Files/Source/ChannelMaster/cmaster.c
@@ -574,6 +574,10 @@ void SetXmtrChannelOutrate (int xmtr_id, int rate, int state)	// 2014-11-24:  Ca
 	SetIVACtxmonSize (0, size);												// set vacOUT0 size for tx monitor
 	SetIVACtxmonRate (1, rate);												// set vacOUT1 rate for tx monitor
 	SetIVACtxmonSize (1, size);												// set vacOUT1 size for tx monitor
+	SetIVACtxmonRate (pcm->cmRCVR, rate);									// dedicated processed TX output source rate
+	SetIVACtxmonSize (pcm->cmRCVR, size);									// dedicated processed TX output source size
+	SetIVACaudioRate (pcm->cmRCVR, rate);									// keep its output-only mixer at the TX rate
+	SetIVACaudioSize (pcm->cmRCVR, size);									// keep its output-only mixer at the TX size
 	for (i = 0; i < pcm->cmRCVR; i++)
 		SetTCITxMonitorRate (i, rate);
 	// PIPE - set Wave Recorder (leave in C# since recorder is there)

--- a/Project Files/Source/ChannelMaster/ivac.c
+++ b/Project Files/Source/ChannelMaster/ivac.c
@@ -30,6 +30,34 @@ warren@wpratt.com
 
 __declspec (align (16))			IVAC pvac[MAX_EXT_VACS];
 
+static void apply_ivac_mixer_mode(IVAC a)
+{
+	if (a->output_only)
+	{
+		// Source 0 = RX audio, source 1 = TX monitor.  Only TX monitor is active
+		// in dedicated processed-TX mode, preventing any wait on RX timing.
+		SetAAudioMixStates(a->mixer, 0, 3, 2);
+		SetAAudioMixWhat(a->mixer, 0, 0, 0);
+		SetAAudioMixWhat(a->mixer, 0, 1, 1);
+	}
+	else
+	{
+		// Restore legacy VAC behaviour exactly: both sources remain active and
+		// MOX/MON determine which source(s) are actually mixed.
+		SetAAudioMixStates(a->mixer, 0, 3, 3);
+		if (!a->mox)
+		{
+			SetAAudioMixWhat(a->mixer, 0, 0, 1);
+			SetAAudioMixWhat(a->mixer, 0, 1, a->mon ? 1 : 0);
+		}
+		else
+		{
+			SetAAudioMixWhat(a->mixer, 0, 0, 0);
+			SetAAudioMixWhat(a->mixer, 0, 1, a->mon ? 1 : 0);
+		}
+	}
+}
+
 void create_resamps(IVAC a)
 {
 	a->INringsize = (int)(2 * a->mic_rate * a->in_latency);		// FROM VAC to mic
@@ -78,6 +106,7 @@ PORT void create_ivac(
 	a->run = run;
 	a->iq_type = iq_type;
 	a->stereo = stereo;
+	a->output_only = 0;
 	a->iq_rate = iq_rate;
 	a->mic_rate = mic_rate;
 	a->audio_rate = audio_rate;
@@ -104,6 +133,7 @@ PORT void create_ivac(
 	{
 		int inrate[2] = { a->audio_rate, a->txmon_rate };
 		a->mixer = create_aamix(-1, id, a->audio_size, a->audio_size, 2, 3, 3, 1.0, 4096, inrate, a->audio_rate, xvac_out, 0.0, 0.0, 0.0, 0.0);
+		apply_ivac_mixer_mode(a);
 	}
 	pvac[id] = a;
 }
@@ -130,6 +160,13 @@ PORT void xvacIN(int id, double* in_tx, int bypass)
 {
 	// used for MIC data to TX
 	IVAC a = pvac[id];
+	if (a->output_only)
+	{
+		// This IVAC instance has no input stream.  Leave the shared TX input
+		// buffer untouched: pipe.c also calls xvacIN() for the inactive VAC,
+		// after the selected microphone source has already populated in_tx.
+		return;
+	}
 	if (a->run)
 		if (!a->vac_bypass && !bypass)
 		{
@@ -208,6 +245,11 @@ int CallbackIVAC(const void* input,
 	(void)statusFlags;
 
 	if (!a->run) return 0;
+	if (a->output_only)
+	{
+		xrmatchOUT(a->rmatchOUT, out_ptr);
+		return 0;
+	}
 									  // [2.10.3.12]MW0LGE handle mono input devices
 	if (a->inParam.channelCount == 1) // mono, dupe to stereo, some mics are mono only, and we require 2 channels
 	{
@@ -266,51 +308,52 @@ PORT int StartAudioIVAC(int id)
 {
 	IVAC a = pvac[id];
 	int error = 0;
-	int in_dev = Pa_HostApiDeviceIndexToDeviceIndex(a->host_api_index, a->input_dev_index);
+	int in_dev = paNoDevice;
 	int out_dev = Pa_HostApiDeviceIndexToDeviceIndex(a->host_api_index, a->output_dev_index);
 
 	int inChannelCount = 2;
 	int outChannelCount = 2;
 
 	const PaDeviceInfo* inDevInfo = NULL;
-	if (in_dev > 0) 
+	if (!a->output_only)
 	{
-		inDevInfo = Pa_GetDeviceInfo(in_dev);
-		if (inDevInfo != NULL) 
+		in_dev = Pa_HostApiDeviceIndexToDeviceIndex(a->host_api_index, a->input_dev_index);
+		if (in_dev >= 0)
 		{
-			inChannelCount = inDevInfo->maxInputChannels;
-			if (inChannelCount > 2) inChannelCount = 2;
+			inDevInfo = Pa_GetDeviceInfo(in_dev);
+			if (inDevInfo != NULL)
+			{
+				inChannelCount = inDevInfo->maxInputChannels;
+				if (inChannelCount > 2) inChannelCount = 2;
+			}
 		}
+		if (inDevInfo == NULL || inChannelCount < 1) return -1;
 	}
+
 	const PaDeviceInfo* outDevInfo = NULL;
-	if (out_dev > 0) 
-	{
+	if (out_dev >= 0)
 		outDevInfo = Pa_GetDeviceInfo(out_dev);
+	if (outDevInfo == NULL) return -1;
 
-		//[2.10.3.12]MW0LGE ignore handling of output channels for now, always use 2
-		//if (outDevInfo != NULL)
-		//{
-		//	outChannelCount = outDevInfo->maxOutputChannels;
-		//	if (outChannelCount > 2) outChannelCount = 2;
-		//}
+	if (!a->output_only)
+	{
+		a->inParam.device = in_dev;
+		a->inParam.channelCount = inChannelCount;
+		a->inParam.suggestedLatency = a->pa_in_latency;
+		a->inParam.sampleFormat = paFloat64;
+		a->inParam.hostApiSpecificStreamInfo = NULL;
 	}
 
-	a->inParam.device = in_dev;
-	a->inParam.channelCount = inChannelCount;
-	a->inParam.suggestedLatency = a->pa_in_latency;
-	a->inParam.sampleFormat = paFloat64;
-	a->inParam.hostApiSpecificStreamInfo = NULL;
-	
 	a->outParam.device = out_dev;
 	a->outParam.channelCount = outChannelCount;
 	a->outParam.suggestedLatency = a->pa_out_latency;
 	a->outParam.sampleFormat = paFloat64;
 	a->outParam.hostApiSpecificStreamInfo = NULL;
 
-	//attempt to get exlusive if wasapi devices
+	// Attempt exclusive mode for WASAPI devices.
 	PaWasapiStreamInfo wasapiInputInfo;
 	PaWasapiStreamInfo wasapiOutputInfo;
-	if (inDevInfo != NULL && a->exclusive_in)
+	if (!a->output_only && inDevInfo != NULL && a->exclusive_in)
 	{
 		const PaHostApiInfo* hostApiInfo = Pa_GetHostApiInfo(inDevInfo->hostApi);
 		if (hostApiInfo != NULL && hostApiInfo->type == paWASAPI)
@@ -320,7 +363,6 @@ PORT int StartAudioIVAC(int id)
 			wasapiInputInfo.version = 1;
 			wasapiInputInfo.flags = (paWinWasapiExclusive | paWinWasapiThreadPriority);
 			wasapiInputInfo.threadPriority = eThreadPriorityProAudio;
-
 			a->inParam.hostApiSpecificStreamInfo = &wasapiInputInfo;
 		}
 	}
@@ -334,26 +376,32 @@ PORT int StartAudioIVAC(int id)
 			wasapiOutputInfo.version = 1;
 			wasapiOutputInfo.flags = (paWinWasapiExclusive | paWinWasapiThreadPriority);
 			wasapiOutputInfo.threadPriority = eThreadPriorityProAudio;
-
 			a->outParam.hostApiSpecificStreamInfo = &wasapiOutputInfo;
 		}
 	}
-	//
 
 	error = Pa_OpenStream(&a->Stream,
-		&a->inParam,
+		a->output_only ? NULL : &a->inParam,
 		&a->outParam,
 		a->vac_rate,
-		a->vac_size,	//paFramesPerBufferUnspecified, 
+		a->vac_size,
 		0,
 		CallbackIVAC,
-		(void*)id);	// pass 'id' as userData
+		(void*)id);
 
-	if (error != 0) return -1;
+	if (error != 0)
+	{
+		a->Stream = NULL;
+		return -1;
+	}
 
 	error = Pa_StartStream(a->Stream);
-
-	if (error != 0) return -1;
+	if (error != 0)
+	{
+		Pa_CloseStream(a->Stream);
+		a->Stream = NULL;
+		return -1;
+	}
 
 	return 1;
 }
@@ -367,7 +415,11 @@ PORT void SetIVACRBReset(int id, int reset)
 PORT void StopAudioIVAC(int id)
 {
 	IVAC a = pvac[id];
-	Pa_CloseStream(a->Stream);
+	if (a->Stream != NULL)
+	{
+		Pa_CloseStream(a->Stream);
+		a->Stream = NULL;
+	}
 }
 
 PORT void SetIVACrun(int id, int run)
@@ -432,6 +484,7 @@ PORT void SetIVACaudioRate(int id, int rate)
 		{
 			int inrate[2] = { a->audio_rate, a->txmon_rate };
 			a->mixer = create_aamix(-1, id, a->audio_size, a->audio_size, 2, 3, 3, 1.0, 4096, inrate, a->audio_rate, xvac_out, 0.0, 0.0, 0.0, 0.0);
+		apply_ivac_mixer_mode(a);
 		}
 		destroy_resamps(a);
 		create_resamps(a);
@@ -450,6 +503,7 @@ void SetIVACtxmonRate(int id, int rate)
 		{
 			int inrate[2] = { a->audio_rate, a->txmon_rate };
 			a->mixer = create_aamix(-1, id, a->audio_size, a->audio_size, 2, 3, 3, 1.0, 4096, inrate, a->audio_rate, xvac_out, 0.0, 0.0, 0.0, 0.0);
+		apply_ivac_mixer_mode(a);
 		}
 	}
 	LeaveCriticalSection(&a->cs_ivac);
@@ -507,6 +561,7 @@ PORT void SetIVACaudioSize(int id, int size)
 	{
 		int inrate[2] = { a->audio_rate, a->txmon_rate };
 		a->mixer = create_aamix(-1, id, a->audio_size, a->audio_size, 2, 3, 3, 1.0, 4096, inrate, a->audio_rate, xvac_out, 0.0, 0.0, 0.0, 0.0);
+		apply_ivac_mixer_mode(a);
 	}
 	destroy_resamps(a);
 	create_resamps(a);
@@ -599,64 +654,21 @@ PORT void SetIVACmox(int id, int mox)
 {
 	IVAC a = pvac[id];
 	a->mox = mox;
-	if (!a->mox)
-	{
-		if (a->mon)
-		{
-			SetAAudioMixWhat(a->mixer, 0, 1, 1);
-			SetAAudioMixWhat(a->mixer, 0, 0, 1);
-		}
-		else
-		{
-			SetAAudioMixWhat(a->mixer, 0, 1, 0);
-			SetAAudioMixWhat(a->mixer, 0, 0, 1);
-		}
-	}
-	else
-	{
-		if (a->mon)
-		{
-			SetAAudioMixWhat(a->mixer, 0, 0, 0);
-			SetAAudioMixWhat(a->mixer, 0, 1, 1);
-		}
-		else
-		{
-			SetAAudioMixWhat(a->mixer, 0, 0, 0);
-			SetAAudioMixWhat(a->mixer, 0, 1, 0);
-		}
-	}
+	apply_ivac_mixer_mode(a);
 }
 
 PORT void SetIVACmon(int id, int mon)
 {
 	IVAC a = pvac[id];
 	a->mon = mon;
-	if (!a->mox)
-	{
-		if (a->mon)
-		{
-			SetAAudioMixWhat(a->mixer, 0, 1, 1);
-			SetAAudioMixWhat(a->mixer, 0, 0, 1);
-		}
-		else
-		{
-			SetAAudioMixWhat(a->mixer, 0, 1, 0);
-			SetAAudioMixWhat(a->mixer, 0, 0, 1);
-		}
-	}
-	else
-	{
-		if (a->mon)
-		{
-			SetAAudioMixWhat(a->mixer, 0, 0, 0);
-			SetAAudioMixWhat(a->mixer, 0, 1, 1);
-		}
-		else
-		{
-			SetAAudioMixWhat(a->mixer, 0, 0, 0);
-			SetAAudioMixWhat(a->mixer, 0, 1, 0);
-		}
-	}
+	apply_ivac_mixer_mode(a);
+}
+
+PORT void SetIVACOutputOnly(int id, int output_only)
+{
+	IVAC a = pvac[id];
+	a->output_only = output_only ? 1 : 0;
+	apply_ivac_mixer_mode(a);
 }
 
 PORT void SetIVACmonVol(int id, double vol)

--- a/Project Files/Source/ChannelMaster/ivac.h
+++ b/Project Files/Source/ChannelMaster/ivac.h
@@ -38,6 +38,7 @@ typedef struct _ivac
 	int run;
 	int iq_type;					// 1 if using raw IQ data; 0 for audio
 	int stereo;						// 1 for stereo; 0 otherwise
+	int output_only;				// 1 for dedicated audio output with no PortAudio input
 	int iq_rate;
 	int mic_rate;
 	int audio_rate;
@@ -129,5 +130,6 @@ extern __declspec(dllexport) void SetIVACmicSize (int id, int size);
 extern __declspec(dllexport) void SetIVACmicRate (int id, int rate);
 extern __declspec(dllexport) void SetIVACaudioRate (int id, int rate);
 extern __declspec(dllexport) void SetIVACaudioSize (int id, int size);
+extern __declspec(dllexport) void SetIVACOutputOnly (int id, int output_only);
 
 #endif

--- a/Project Files/Source/ChannelMaster/pipe.c
+++ b/Project Files/Source/ChannelMaster/pipe.c
@@ -112,6 +112,26 @@ void create_pipe()
 		ppip->rcvr[i].playwave_run = 0;			// playwave run
 		ppip->rcvr[i].recordwave_run = 0;		// recordwave run
 	}
+	// Receiver-backed IVAC instances occupy IDs 0 through cmRCVR - 1.
+	// Reserve the first unused ID for an independent output-only stream carrying
+	// processed TX monitor audio. Its mixer runs at the TX monitor rate and does
+	// not depend on any receiver stream.
+	create_ivac(
+		pcm->cmRCVR,							// first IVAC ID not owned by a receiver
+		0,									// run
+		0,									// audio, not raw I-Q
+		0,									// mono source
+		pcm->xcm_inrate[inid(0, 0)],		// unused I-Q rate
+		pcm->xcm_inrate[inid(1, 0)],		// unused mic rate
+		pcm->xmtr[0].ch_outrate,			// mixer/output rate
+		pcm->xmtr[0].ch_outrate,			// TX monitor rate
+		48000,								// sound-device rate
+		pcm->xcm_insize[inid(1, 0)],		// unused mic size
+		pcm->xcm_insize[inid(0, 0)],		// unused I-Q size
+		pcm->xmtr[0].ch_outsize,			// mixer/output size
+		pcm->xmtr[0].ch_outsize,			// TX monitor size
+		512);								// sound-device buffer size
+	SetIVACOutputOnly(pcm->cmRCVR, 1);
 	create_tci();
 	create_spc0();
 }
@@ -126,6 +146,7 @@ void destroy_pipe()
 		_aligned_free (ppip->rbuff[i]);
 		destroy_ivac (i);
 	}
+	destroy_ivac(pcm->cmRCVR);
 	_aligned_free (ppip->rbuff);
 	destroy_siphonEXT (0);
 }
@@ -233,6 +254,7 @@ void xpipe (int stream, int pos, double** buffs)
 			xscope(0, 1, buffs[2]);																// scope
 			xvacOUT(0, 2, buffs[2]);															// data to VAC 0
 			xvacOUT(1, 2, buffs[2]);															// data to VAC 1
+			xvacOUT(pcm->cmRCVR, 2, buffs[2]);										// data to dedicated processed TX output
 			for (i = 0; i < pcm->cmRCVR; i++)
 				xtciOUT(i, 2, buffs[2]);														// tx monitor into each TCI rx audio stream
 			xrecordwave(0, 1, 1, buffs[2]);														// wav recorder 0

--- a/Project Files/Source/Console/app.config
+++ b/Project Files/Source/Console/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" /></startup>
   <runtime>
@@ -67,6 +67,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-10.0.0.4" newVersion="10.0.0.4" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Resources.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.8" newVersion="10.0.0.8" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Project Files/Source/Console/audio.cs
+++ b/Project Files/Source/Console/audio.cs
@@ -862,6 +862,82 @@ namespace Thetis
             set { output_dev3 = value; }
         }
 
+        // Independent post-DSP transmit-audio output.  The native IVAC ID is
+        // the first one not associated with a software receiver, leaving VAC1
+        // and VAC2 completely unchanged and available for their normal roles.
+        private static bool processed_tx_output_enabled = false;
+        private static int processed_tx_output_host = 0;
+        private static int processed_tx_output_device = 0;
+        private static int processed_tx_output_sample_rate = 48000;
+        private static int processed_tx_output_block_size = 512;
+        private static int processed_tx_output_exclusive = 0;
+        private static double processed_tx_output_gain_db = 0.0;
+
+        private static int ProcessedTXOutputIVACID
+        {
+            get { return cmaster.CMrcvr; }
+        }
+
+        public static bool ProcessedTXOutputEnabled
+        {
+            get { return processed_tx_output_enabled; }
+            set
+            {
+                if (processed_tx_output_enabled == value) return;
+                processed_tx_output_enabled = value;
+                if (console != null && console.PowerOn)
+                    EnableProcessedTXOutput(value);
+            }
+        }
+
+        public static int ProcessedTXOutputHost
+        {
+            get { return processed_tx_output_host; }
+            set { processed_tx_output_host = value; }
+        }
+
+        public static int ProcessedTXOutputDevice
+        {
+            get { return processed_tx_output_device; }
+            set { processed_tx_output_device = value; }
+        }
+
+        public static int ProcessedTXOutputSampleRate
+        {
+            get { return processed_tx_output_sample_rate; }
+            set { processed_tx_output_sample_rate = value; }
+        }
+
+        public static int ProcessedTXOutputBlockSize
+        {
+            get { return processed_tx_output_block_size; }
+            set { processed_tx_output_block_size = value; }
+        }
+
+        public static int ProcessedTXOutputExclusive
+        {
+            get { return processed_tx_output_exclusive; }
+            set { processed_tx_output_exclusive = value; }
+        }
+
+        public static double ProcessedTXOutputGainDB
+        {
+            get { return processed_tx_output_gain_db; }
+            set
+            {
+                processed_tx_output_gain_db = value;
+                if (processed_tx_output_enabled && console != null && console.PowerOn)
+                    ivac.SetIVACmonVol(ProcessedTXOutputIVACID, Math.Pow(10.0, processed_tx_output_gain_db / 20.0));
+            }
+        }
+
+        public static void RestartProcessedTXOutput()
+        {
+            if (!processed_tx_output_enabled || console == null || !console.PowerOn) return;
+            EnableProcessedTXOutput(false);
+            EnableProcessedTXOutput(true);
+        }
+
         private static int latency2 = 120;
         public static int Latency2
         {
@@ -1742,6 +1818,82 @@ namespace Thetis
                 ivac.StopAudioIVAC(1);                
             }
             Thread.Sleep(10); // prevent ASIO exception
+        }
+
+        public static void EnableProcessedTXOutput(bool enable)
+        {
+            int id = ProcessedTXOutputIVACID;
+
+            if (enable)
+            {
+                int global_output = (int)PA19.PA_HostApiDeviceIndexToDeviceIndex(
+                    processed_tx_output_host, processed_tx_output_device);
+                if (global_output < 0)
+                {
+                    MessageBox.Show("The selected Processed TX Output device is unavailable.\n" +
+                        "Please select another output device on Setup -> Audio -> TX Output.",
+                        "Processed TX Output Error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                    return;
+                }
+
+                PA19.PaDeviceInfo out_info = PA19.PA_GetDeviceInfo(global_output);
+                if (out_info.maxOutputChannels < 2)
+                {
+                    MessageBox.Show("The selected Processed TX Output device does not expose two output channels.\n" +
+                        "Please select another output device on Setup -> Audio -> TX Output.",
+                        "Processed TX Output Error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                    return;
+                }
+
+                double out_latency = out_info.defaultLowOutputLatency;
+
+                ivac.SetIVACrun(id, 0);
+                ivac.SetIVACOutputOnly(id, 1);
+                ivac.SetIVACiqType(id, 0);
+                ivac.SetIVACstereo(id, 0);
+                ivac.SetIVAChostAPIindex(id, processed_tx_output_host);
+                ivac.SetIVACoutputDEVindex(id, processed_tx_output_device);
+                ivac.SetIVACnumChannels(id, 2);
+                ivac.SetIVACvacRate(id, processed_tx_output_sample_rate);
+                ivac.SetIVACvacSize(id, processed_tx_output_block_size);
+                ivac.SetIVACOutLatency(id, out_latency, 0);
+                ivac.SetIVACPAOutLatency(id, out_latency, 1);
+                ivac.SetIVACExclusiveIn(id, 0);
+                ivac.SetIVACExclusiveOut(id, processed_tx_output_exclusive);
+                ivac.SetIVACmonVol(id, Math.Pow(10.0, processed_tx_output_gain_db / 20.0));
+
+                try
+                {
+                    bool started = ivac.StartAudioIVAC(id) == 1;
+                    if (started && console.PowerOn)
+                        ivac.SetIVACrun(id, 1);
+                    else
+                        MessageBox.Show("The program could not start the Processed TX Output stream.\n" +
+                            "Please examine Setup -> Audio -> TX Output and try again.",
+                            "Processed TX Output Startup Error",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+                }
+                catch (Exception)
+                {
+                    MessageBox.Show("The program is having trouble starting the Processed TX Output stream.\n" +
+                        "Please examine Setup -> Audio -> TX Output and try again.",
+                        "Processed TX Output Startup Error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+            }
+            else
+            {
+                ivac.SetIVACrun(id, 0);
+                ivac.StopAudioIVAC(id);
+            }
+
+            Thread.Sleep(10); // prevent PortAudio/WASAPI restart exceptions
         }
 
         private static RadioProtocol _lastRadioProtocol = RadioProtocol.None;

--- a/Project Files/Source/Console/audio.cs
+++ b/Project Files/Source/Console/audio.cs
@@ -1826,6 +1826,8 @@ namespace Thetis
 
             if (enable)
             {
+                if (console == null || !console.PowerOn) return;
+
                 int global_output = (int)PA19.PA_HostApiDeviceIndexToDeviceIndex(
                     processed_tx_output_host, processed_tx_output_device);
                 if (global_output < 0)
@@ -1851,7 +1853,9 @@ namespace Thetis
 
                 double out_latency = out_info.defaultLowOutputLatency;
 
+                // Stop any running stream first so PortAudio callback does not execute while resamplers are recreated
                 ivac.SetIVACrun(id, 0);
+                ivac.StopAudioIVAC(id);
                 ivac.SetIVACOutputOnly(id, 1);
                 ivac.SetIVACiqType(id, 0);
                 ivac.SetIVACstereo(id, 0);

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -27192,6 +27192,7 @@ namespace Thetis
 
                 if (vac_enabled) VACEnabled = true;  //Don't trigger StopAudioIVAC if the VACs aren't needed now
                 if (vac2_enabled) VAC2Enabled = true;
+                if (Audio.ProcessedTXOutputEnabled) Audio.EnableProcessedTXOutput(true);
 
                 Thread.Sleep(100); // wait for hardware to settle before starting audio (possible sample rate change)
                 psform.ForcePS();
@@ -27457,6 +27458,12 @@ namespace Thetis
                 {
                     ivac.SetIVACrun(1, 0);
                     ivac.StopAudioIVAC(1);
+                }
+
+                if (Audio.ProcessedTXOutputEnabled)
+                {
+                    ivac.SetIVACrun(cmaster.CMrcvr, 0);
+                    ivac.StopAudioIVAC(cmaster.CMrcvr);
                 }
 
                 if (multimeter_thread != null)

--- a/Project Files/Source/Console/console.cs
+++ b/Project Files/Source/Console/console.cs
@@ -19928,7 +19928,20 @@ namespace Thetis
                 if (!IsSetupFormNull)  //[2.10.3.5]MW0LGE added
                     Audio.ScopeTime = SetupForm.ScopeTime;
                 Display.SampleRateTX = value;
+
+                bool restartProcessedTx = Audio.ProcessedTXOutputEnabled && PowerOn;
+                if (restartProcessedTx)
+                {
+                    ivac.SetIVACrun(cmaster.CMrcvr, 0);
+                    ivac.StopAudioIVAC(cmaster.CMrcvr);
+                }
+
                 cmaster.SetXmtrChannelOutrate(0, value, cmaster.MONMixState);
+
+                if (restartProcessedTx)
+                {
+                    Audio.EnableProcessedTXOutput(true);
+                }
 
                 switch (_rx1_dsp_mode)
                 {
@@ -27192,7 +27205,6 @@ namespace Thetis
 
                 if (vac_enabled) VACEnabled = true;  //Don't trigger StopAudioIVAC if the VACs aren't needed now
                 if (vac2_enabled) VAC2Enabled = true;
-                if (Audio.ProcessedTXOutputEnabled) Audio.EnableProcessedTXOutput(true);
 
                 Thread.Sleep(100); // wait for hardware to settle before starting audio (possible sample rate change)
                 psform.ForcePS();
@@ -27217,6 +27229,8 @@ namespace Thetis
                     chkPower.Checked = false;
                     return;
                 }
+
+                if (Audio.ProcessedTXOutputEnabled) Audio.EnableProcessedTXOutput(true);
                 if (!IsSetupFormNull) SetupForm.BoardWarning = NetworkIO.BoardMismatch; //[2.10.3.9]MW0LGE show warning in setup if board does not match expected
 
                 //MW0LGE_21k9 these two moved after the audio start

--- a/Project Files/Source/Console/ivac.cs
+++ b/Project Files/Source/Console/ivac.cs
@@ -134,6 +134,9 @@ namespace Thetis
         [DllImport("ChannelMaster.dll", EntryPoint = "SetIVACcombine", CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetIVACcombine(int id, int combine);
 
+        [DllImport("ChannelMaster.dll", EntryPoint = "SetIVACOutputOnly", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void SetIVACOutputOnly(int id, int output_only);
+
         [DllImport("ChannelMaster.dll", EntryPoint = "SetIVACmon", CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetIVACmon(int id, int mon);
 

--- a/Project Files/Source/Console/setup.cs
+++ b/Project Files/Source/Console/setup.cs
@@ -100,12 +100,36 @@ namespace Thetis
 
         #endregion
 
+        #region Independent Processed TX Output Controls
+
+        private System.Windows.Forms.GroupBoxTS grpProcessedTXDevice;
+        private System.Windows.Forms.GroupBoxTS grpProcessedTXBuffer;
+        private System.Windows.Forms.GroupBoxTS grpProcessedTXSampleRate;
+        private System.Windows.Forms.GroupBoxTS grpProcessedTXGain;
+        private System.Windows.Forms.GroupBoxTS grpProcessedTXWASAPI;
+        private System.Windows.Forms.LabelTS lblProcessedTXDriver;
+        private System.Windows.Forms.ComboBoxTS comboProcessedTXDriver;
+        private System.Windows.Forms.LabelTS lblProcessedTXInput;
+        private System.Windows.Forms.LabelTS lblProcessedTXOutput;
+        private System.Windows.Forms.ComboBoxTS comboProcessedTXOutput;
+        private System.Windows.Forms.ComboBoxTS comboProcessedTXBuffer;
+        private System.Windows.Forms.ComboBoxTS comboProcessedTXSampleRate;
+        private System.Windows.Forms.LabelTS lblProcessedTXGain;
+        private System.Windows.Forms.NumericUpDownTS udProcessedTXGain;
+        private System.Windows.Forms.LabelTS lblProcessedTXGainUnit;
+        private System.Windows.Forms.CheckBoxTS chkProcessedTXExclusive;
+        private System.Windows.Forms.CheckBoxTS chkProcessedTXOutputEnable;
+        private System.Windows.Forms.LabelTS lblProcessedTXDescription;
+
+        #endregion
+
         #region Constructor and Destructor
 
         public Setup(Console c)
         {
             LogTool.AddLogEntry("      Setup init components...", "INITCOMPSETUP");
             InitializeComponent();
+            InitializeProcessedTXOutputControls();
 
             _original_pnlP1_adcs_location = pnlP1_adcs.Location;
 
@@ -126,6 +150,239 @@ namespace Thetis
 
             //everything here moved to AfterConstructor, which is called during singleton instance // G7KLJ's idea/implementation
         }
+
+        private void InitializeProcessedTXOutputControls()
+        {
+            grpProcessedTXDevice = new System.Windows.Forms.GroupBoxTS();
+            grpProcessedTXDevice.Name = "grpProcessedTXDevice";
+            grpProcessedTXDevice.Text = "Processed TX Output Setup";
+            grpProcessedTXDevice.Location = new System.Drawing.Point(8, 8);
+            grpProcessedTXDevice.Size = new System.Drawing.Size(430, 125);
+
+            lblProcessedTXDriver = new System.Windows.Forms.LabelTS();
+            lblProcessedTXDriver.Name = "lblProcessedTXDriver";
+            lblProcessedTXDriver.Text = "Driver:";
+            lblProcessedTXDriver.AutoSize = true;
+            lblProcessedTXDriver.Location = new System.Drawing.Point(12, 25);
+
+            comboProcessedTXDriver = new System.Windows.Forms.ComboBoxTS();
+            comboProcessedTXDriver.Name = "comboProcessedTXDriver";
+            comboProcessedTXDriver.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboProcessedTXDriver.Location = new System.Drawing.Point(64, 22);
+            comboProcessedTXDriver.Size = new System.Drawing.Size(180, 21);
+
+            lblProcessedTXInput = new System.Windows.Forms.LabelTS();
+            lblProcessedTXInput.Name = "lblProcessedTXInput";
+            lblProcessedTXInput.Text = "Input: None (output-only)";
+            lblProcessedTXInput.AutoSize = true;
+            lblProcessedTXInput.Location = new System.Drawing.Point(12, 55);
+
+            lblProcessedTXOutput = new System.Windows.Forms.LabelTS();
+            lblProcessedTXOutput.Name = "lblProcessedTXOutput";
+            lblProcessedTXOutput.Text = "Output:";
+            lblProcessedTXOutput.AutoSize = true;
+            lblProcessedTXOutput.Location = new System.Drawing.Point(12, 88);
+
+            comboProcessedTXOutput = new System.Windows.Forms.ComboBoxTS();
+            comboProcessedTXOutput.Name = "comboProcessedTXOutput";
+            comboProcessedTXOutput.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboProcessedTXOutput.Location = new System.Drawing.Point(64, 85);
+            comboProcessedTXOutput.Size = new System.Drawing.Size(350, 21);
+
+            grpProcessedTXDevice.Controls.Add(lblProcessedTXDriver);
+            grpProcessedTXDevice.Controls.Add(comboProcessedTXDriver);
+            grpProcessedTXDevice.Controls.Add(lblProcessedTXInput);
+            grpProcessedTXDevice.Controls.Add(lblProcessedTXOutput);
+            grpProcessedTXDevice.Controls.Add(comboProcessedTXOutput);
+
+            grpProcessedTXBuffer = new System.Windows.Forms.GroupBoxTS();
+            grpProcessedTXBuffer.Name = "grpProcessedTXBuffer";
+            grpProcessedTXBuffer.Text = "Buffer Size";
+            grpProcessedTXBuffer.Location = new System.Drawing.Point(8, 145);
+            grpProcessedTXBuffer.Size = new System.Drawing.Size(105, 65);
+
+            comboProcessedTXBuffer = new System.Windows.Forms.ComboBoxTS();
+            comboProcessedTXBuffer.Name = "comboProcessedTXBuffer";
+            comboProcessedTXBuffer.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboProcessedTXBuffer.Location = new System.Drawing.Point(16, 26);
+            comboProcessedTXBuffer.Size = new System.Drawing.Size(72, 21);
+            comboProcessedTXBuffer.Items.AddRange(new object[] { "64", "128", "256", "512", "1024", "2048" });
+            comboProcessedTXBuffer.SelectedItem = "512";
+            grpProcessedTXBuffer.Controls.Add(comboProcessedTXBuffer);
+
+            grpProcessedTXSampleRate = new System.Windows.Forms.GroupBoxTS();
+            grpProcessedTXSampleRate.Name = "grpProcessedTXSampleRate";
+            grpProcessedTXSampleRate.Text = "Sample Rate";
+            grpProcessedTXSampleRate.Location = new System.Drawing.Point(121, 145);
+            grpProcessedTXSampleRate.Size = new System.Drawing.Size(105, 65);
+
+            comboProcessedTXSampleRate = new System.Windows.Forms.ComboBoxTS();
+            comboProcessedTXSampleRate.Name = "comboProcessedTXSampleRate";
+            comboProcessedTXSampleRate.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            comboProcessedTXSampleRate.Location = new System.Drawing.Point(16, 26);
+            comboProcessedTXSampleRate.Size = new System.Drawing.Size(72, 21);
+            comboProcessedTXSampleRate.Items.AddRange(new object[] { "44100", "48000", "96000", "192000" });
+            comboProcessedTXSampleRate.SelectedItem = "48000";
+            grpProcessedTXSampleRate.Controls.Add(comboProcessedTXSampleRate);
+
+            grpProcessedTXGain = new System.Windows.Forms.GroupBoxTS();
+            grpProcessedTXGain.Name = "grpProcessedTXGain";
+            grpProcessedTXGain.Text = "Gain (dB)";
+            grpProcessedTXGain.Location = new System.Drawing.Point(234, 145);
+            grpProcessedTXGain.Size = new System.Drawing.Size(105, 65);
+
+            lblProcessedTXGain = new System.Windows.Forms.LabelTS();
+            lblProcessedTXGain.Name = "lblProcessedTXGain";
+            lblProcessedTXGain.Text = "TX:";
+            lblProcessedTXGain.AutoSize = true;
+            lblProcessedTXGain.Location = new System.Drawing.Point(8, 29);
+
+            udProcessedTXGain = new System.Windows.Forms.NumericUpDownTS();
+            udProcessedTXGain.Name = "udProcessedTXGain";
+            udProcessedTXGain.DecimalPlaces = 1;
+            udProcessedTXGain.Increment = 0.5M;
+            udProcessedTXGain.Minimum = -30M;
+            udProcessedTXGain.Maximum = 20M;
+            udProcessedTXGain.Value = 0M;
+            udProcessedTXGain.Location = new System.Drawing.Point(34, 26);
+            udProcessedTXGain.Size = new System.Drawing.Size(48, 20);
+
+            lblProcessedTXGainUnit = new System.Windows.Forms.LabelTS();
+            lblProcessedTXGainUnit.Name = "lblProcessedTXGainUnit";
+            lblProcessedTXGainUnit.Text = "dB";
+            lblProcessedTXGainUnit.AutoSize = true;
+            lblProcessedTXGainUnit.Location = new System.Drawing.Point(82, 29);
+
+            grpProcessedTXGain.Controls.Add(lblProcessedTXGain);
+            grpProcessedTXGain.Controls.Add(udProcessedTXGain);
+            grpProcessedTXGain.Controls.Add(lblProcessedTXGainUnit);
+
+            grpProcessedTXWASAPI = new System.Windows.Forms.GroupBoxTS();
+            grpProcessedTXWASAPI.Name = "grpProcessedTXWASAPI";
+            grpProcessedTXWASAPI.Text = "WASAPI";
+            grpProcessedTXWASAPI.Location = new System.Drawing.Point(347, 145);
+            grpProcessedTXWASAPI.Size = new System.Drawing.Size(120, 65);
+
+            chkProcessedTXExclusive = new System.Windows.Forms.CheckBoxTS();
+            chkProcessedTXExclusive.Name = "chkProcessedTXExclusive";
+            chkProcessedTXExclusive.Text = "Exclusive Out";
+            chkProcessedTXExclusive.AutoSize = true;
+            chkProcessedTXExclusive.Location = new System.Drawing.Point(12, 28);
+            chkProcessedTXExclusive.UseVisualStyleBackColor = true;
+            grpProcessedTXWASAPI.Controls.Add(chkProcessedTXExclusive);
+
+            chkProcessedTXOutputEnable = new System.Windows.Forms.CheckBoxTS();
+            chkProcessedTXOutputEnable.Name = "chkProcessedTXOutputEnable";
+            chkProcessedTXOutputEnable.Text = "Enable Processed TX Output";
+            chkProcessedTXOutputEnable.AutoSize = true;
+            chkProcessedTXOutputEnable.Location = new System.Drawing.Point(12, 230);
+            chkProcessedTXOutputEnable.UseVisualStyleBackColor = true;
+
+            lblProcessedTXDescription = new System.Windows.Forms.LabelTS();
+            lblProcessedTXDescription.Name = "lblProcessedTXDescription";
+            lblProcessedTXDescription.Text = "Post-TX-DSP audio to an external transmitter. Independent of VAC1 and VAC2; no input device is opened.";
+            lblProcessedTXDescription.AutoSize = false;
+            lblProcessedTXDescription.Location = new System.Drawing.Point(12, 260);
+            lblProcessedTXDescription.Size = new System.Drawing.Size(650, 36);
+
+            tpProcessedTXOutput.Controls.Add(grpProcessedTXDevice);
+            tpProcessedTXOutput.Controls.Add(grpProcessedTXBuffer);
+            tpProcessedTXOutput.Controls.Add(grpProcessedTXSampleRate);
+            tpProcessedTXOutput.Controls.Add(grpProcessedTXGain);
+            tpProcessedTXOutput.Controls.Add(grpProcessedTXWASAPI);
+            tpProcessedTXOutput.Controls.Add(chkProcessedTXOutputEnable);
+            tpProcessedTXOutput.Controls.Add(lblProcessedTXDescription);
+
+            foreach (object host in Audio.GetPAHosts())
+                comboProcessedTXDriver.Items.Add(host);
+
+            int defaultHost = 0;
+            for (int i = 0; i < comboProcessedTXDriver.Items.Count; i++)
+                if (comboProcessedTXDriver.Items[i].ToString().IndexOf("WASAPI", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    defaultHost = i;
+                    break;
+                }
+            if (comboProcessedTXDriver.Items.Count > 0)
+                comboProcessedTXDriver.SelectedIndex = defaultHost;
+            PopulateProcessedTXOutputs(true);
+
+            comboProcessedTXDriver.SelectedIndexChanged += comboProcessedTXDriver_SelectedIndexChanged;
+            comboProcessedTXOutput.SelectedIndexChanged += comboProcessedTXSettingChanged;
+            comboProcessedTXBuffer.SelectedIndexChanged += comboProcessedTXSettingChanged;
+            comboProcessedTXSampleRate.SelectedIndexChanged += comboProcessedTXSettingChanged;
+            udProcessedTXGain.ValueChanged += udProcessedTXGain_ValueChanged;
+            chkProcessedTXExclusive.CheckedChanged += comboProcessedTXSettingChanged;
+            chkProcessedTXOutputEnable.CheckedChanged += chkProcessedTXOutputEnable_CheckedChanged;
+
+            ApplyProcessedTXOutputSettings(false);
+        }
+
+        private void PopulateProcessedTXOutputs(bool chooseUSBCodec)
+        {
+            comboProcessedTXOutput.Items.Clear();
+            if (comboProcessedTXDriver.SelectedIndex < 0) return;
+
+            foreach (object device in Audio.GetPAOutputDevices(comboProcessedTXDriver.SelectedIndex))
+                comboProcessedTXOutput.Items.Add(device);
+
+            if (comboProcessedTXOutput.Items.Count == 0) return;
+            int selected = 0;
+            if (chooseUSBCodec)
+                for (int i = 0; i < comboProcessedTXOutput.Items.Count; i++)
+                    if (comboProcessedTXOutput.Items[i].ToString().IndexOf("USB Audio CODEC", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        selected = i;
+                        break;
+                    }
+            comboProcessedTXOutput.SelectedIndex = selected;
+        }
+
+        private void ApplyProcessedTXOutputSettings(bool restart)
+        {
+            if (comboProcessedTXDriver.SelectedIndex >= 0)
+                Audio.ProcessedTXOutputHost = comboProcessedTXDriver.SelectedIndex;
+
+            if (comboProcessedTXOutput.SelectedItem is PADeviceInfo)
+                Audio.ProcessedTXOutputDevice = ((PADeviceInfo)comboProcessedTXOutput.SelectedItem).Index;
+
+            int value;
+            if (comboProcessedTXSampleRate.SelectedItem != null &&
+                Int32.TryParse(comboProcessedTXSampleRate.SelectedItem.ToString(), out value))
+                Audio.ProcessedTXOutputSampleRate = value;
+            if (comboProcessedTXBuffer.SelectedItem != null &&
+                Int32.TryParse(comboProcessedTXBuffer.SelectedItem.ToString(), out value))
+                Audio.ProcessedTXOutputBlockSize = value;
+
+            Audio.ProcessedTXOutputExclusive = chkProcessedTXExclusive.Checked ? 1 : 0;
+            Audio.ProcessedTXOutputGainDB = (double)udProcessedTXGain.Value;
+
+            if (restart && !initializing && Audio.ProcessedTXOutputEnabled)
+                Audio.RestartProcessedTXOutput();
+        }
+
+        private void comboProcessedTXDriver_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            PopulateProcessedTXOutputs(false);
+            ApplyProcessedTXOutputSettings(true);
+        }
+
+        private void comboProcessedTXSettingChanged(object sender, EventArgs e)
+        {
+            ApplyProcessedTXOutputSettings(true);
+        }
+
+        private void udProcessedTXGain_ValueChanged(object sender, EventArgs e)
+        {
+            Audio.ProcessedTXOutputGainDB = (double)udProcessedTXGain.Value;
+        }
+
+        private void chkProcessedTXOutputEnable_CheckedChanged(object sender, EventArgs e)
+        {
+            ApplyProcessedTXOutputSettings(false);
+            Audio.ProcessedTXOutputEnabled = chkProcessedTXOutputEnable.Checked;
+        }
+
         internal void AfterConstructor()
         {
             LogTool.AddLogEntry("      Setup setup controls...", "SETUP_CONT");

--- a/Project Files/Source/Console/setup.designer.cs
+++ b/Project Files/Source/Console/setup.designer.cs
@@ -1804,6 +1804,7 @@
             this.comboAudioInput3 = new System.Windows.Forms.ComboBoxTS();
             this.comboAudioDriver3 = new System.Windows.Forms.ComboBoxTS();
             this.chkVAC2Enable = new System.Windows.Forms.CheckBoxTS();
+            this.tpProcessedTXOutput = new System.Windows.Forms.TabPage();
             this.tpAudioOptions = new System.Windows.Forms.TabPage();
             this.chkVAC2WillMute = new System.Windows.Forms.CheckBoxTS();
             this.groupBoxTS29 = new System.Windows.Forms.GroupBoxTS();
@@ -27527,6 +27528,7 @@
             // 
             this.tcAudio.Controls.Add(this.tpVAC);
             this.tcAudio.Controls.Add(this.tpVAC2);
+            this.tcAudio.Controls.Add(this.tpProcessedTXOutput);
             this.tcAudio.Controls.Add(this.tpAudioOptions);
             this.tcAudio.Controls.Add(this.tpAdvancedAudio);
             this.tcAudio.Controls.Add(this.tpCMAsio);
@@ -27536,6 +27538,16 @@
             this.tcAudio.SelectedIndex = 0;
             this.tcAudio.Size = new System.Drawing.Size(720, 430);
             this.tcAudio.TabIndex = 35;
+            // 
+            // tpProcessedTXOutput
+            // 
+            this.tpProcessedTXOutput.Location = new System.Drawing.Point(4, 22);
+            this.tpProcessedTXOutput.Name = "tpProcessedTXOutput";
+            this.tpProcessedTXOutput.Padding = new System.Windows.Forms.Padding(3);
+            this.tpProcessedTXOutput.Size = new System.Drawing.Size(712, 404);
+            this.tpProcessedTXOutput.TabIndex = 6;
+            this.tpProcessedTXOutput.Text = "TX Output";
+            this.tpProcessedTXOutput.UseVisualStyleBackColor = true;
             // 
             // tpVAC
             // 
@@ -72802,6 +72814,7 @@
         private ComboBoxTS comboKBXITDown;
         private ButtonTS btnCATTest;
         private TabControl tcAudio;
+        private TabPage tpProcessedTXOutput;
         public ComboBoxTS comboAudioSampleRate1;
         private GroupBoxTS grpAudioSampleRate1;
         private GroupBoxTS grpAudioDetails2;


### PR DESCRIPTION
## Problem

I use a Red Pitaya as the network-connected HPSDR transceiver and Thetis as the DSP/control application. However, I use an Icom IC-7100 as the RF transmitter (I do not exploit the rf signal generated by Redpitaya HPSDR transceiver). The microphone enters Thetis through VAC1 so that VOX and the normal Thetis transmit processing can be used.

The missing path was an independent way to send the resulting post-TX-DSP audio from Thetis to the IC-7100 USB audio device via a dedicated audio interface that is independent from the MON function. Reusing VAC2 for this output prevents VAC2 from serving RX2 and can interfere with the selected VAC1 microphone buffer and was not my design choice. 

Required behaviour:
- VAC1 remains the microphone input.
- The microphone continues through the normal Thetis TX DSP chain.
- Processed TX audio is sent to an independently selected output device.
- VAC2 remains unchanged and available for RX2.
- The user-facing MON function remains completely unchanged and independent of the dedicated TX Output.
- This change adds a parallel processed-audio output but does not disable the existing HPSDR TX I/Q, hardware MOX or Red Pitaya RF path.  If TX Output is enabled in the Audio setup menu, the Red Pitaya still transmits rf normally, while transmit audio is also sent to the IC-7100 audio interface. Changing TX Output Gain in the Audio menu changes only the IC-7100 audio level.
- Selecting "RX-only" for the RedPitaya in the setup menu is not supported by this change, as selecting "RX only" disables MOX by design. 

## Implementation

- Adds a dedicated output-only PortAudio/IVAC stream using the first IVAC ID not associated with a software receiver (`cmRCVR`).
- Opens only a PortAudio output device and routes Thetis’s internal post-TX-DSP audio stream to it. Although this stream is called “TX monitor” internally, it is independent of the user-facing MON control. The dedicated TX Output works with MON enabled or disabled, and this change does not alter existing MON behaviour.
- Routes post-DSP TX-monitor samples to the dedicated stream without modifying the shared microphone buffer.
- Adds independent enable, host/driver, output, sample-rate, buffer-size, gain and WASAPI exclusive-output controls under **Setup -> Audio -> TX Output**.
- Starts/stops the stream with Thetis power and validates the selected device and channels.
- Declares the new page in the WinForms designer so it is reliably exposed in compiled builds.
- Leaves VAC1 and VAC2 behaviour unchanged.

## Validation

The complete solution built successfully as Release x64 in GitHub Actions on `windows-2025` and was tested successfully with:

- Thetis x64 on Windows
- Red Pitaya as the network-connected SDR transceiver.
- Microphone input through VAC1
- Icom IC-7100 USB Audio CODEC as the external TX output

Results: microphone audio was processed and transmitted by the IC-7100; dedicated TX Output gain and Thetis compression produced the expected IC-7100 ALC changes; VOX worked; VAC2 remained available for RX2; and no VAC1 microphone regression was observed.

The main Thetis MIC Gain control not scaling VAC-sourced microphone audio is existing Thetis behaviour and is unchanged.

Build/validation run: https://github.com/satfan52/Thetis/actions/runs/33833661006

Tested binary: https://github.com/satfan52/Thetis/releases/download/hybrid-sdr-testset-2026-09-03/Thetis-HybridSDR-D-Dedicated-TX-Output-Designer-Fix-x64.zip

ZIP SHA-256: `e7f900e0a0cec49188d231192ecf87d75ff91ca97d8298ebd874bdb0b17a71a0`